### PR TITLE
Fetch external key field that has not been provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import typename from "./test-cases/typename";
 import unionInterfaceDistributed from "./test-cases/union-interface-distributed";
 import mutations from "./test-cases/mutations";
 import abstractTypes from "./test-cases/abstract-types";
+import fed1ExternalExtendsResolvable from "./test-cases/fed1-external-extends-resolvable";
 import { Env } from "./env";
 
 const testCases = [
@@ -68,6 +69,7 @@ const testCases = [
   fed2ExternalExtends,
   fed1ExternalExtension,
   fed2ExternalExtension,
+  fed1ExternalExtendsResolvable,
   parentEntityCall,
   parentEntityCallComplex,
   sharedRoot,

--- a/src/test-cases/fed1-external-extends-resolvable/a.subgraph.ts
+++ b/src/test-cases/fed1-external-extends-resolvable/a.subgraph.ts
@@ -1,0 +1,40 @@
+import { createSubgraph } from "../../subgraph";
+import { products } from "./data";
+
+export default createSubgraph("a", {
+  typeDefs: /* GraphQL */ `
+    type Query {
+      productInA: Product
+    }
+
+    type Product @key(fields: "id") {
+      id: ID!
+      name: String
+      pid: ID
+    }
+  `,
+  resolvers: {
+    Query: {
+      productInA() {
+        return {
+          id: products[0].id,
+          name: products[0].name,
+          pid: products[0].pid,
+        };
+      },
+    },
+    Product: {
+      __resolveReference(key: { id: string }) {
+        if (products[0].id !== key.id) {
+          return null;
+        }
+
+        return {
+          id: products[0].id,
+          name: products[0].name,
+          pid: products[0].pid,
+        };
+      },
+    },
+  },
+});

--- a/src/test-cases/fed1-external-extends-resolvable/b.subgraph.ts
+++ b/src/test-cases/fed1-external-extends-resolvable/b.subgraph.ts
@@ -1,0 +1,52 @@
+import { createSubgraph } from "../../subgraph";
+import { products } from "./data";
+
+export default createSubgraph("b", {
+  typeDefs: /* GraphQL */ `
+    type Query {
+      productInB: Product
+    }
+
+    extend type Product @key(fields: "id name") @key(fields: "upc") {
+      id: ID @external
+      name: String @external
+      upc: String @external
+      price: Float!
+    }
+  `,
+  resolvers: {
+    Query: {
+      productInB: () => {
+        return {
+          id: products[0].id,
+          name: products[0].name,
+          upc: products[0].upc,
+          price: products[0].price,
+        };
+      },
+    },
+    Product: {
+      __resolveReference: (
+        key:
+          | { id: string; name: string }
+          | {
+              upc: string;
+            }
+      ) => {
+        const product =
+          "id" in key
+            ? products.find((p) => p.id === key.id && p.name === key.name)
+            : products.find((p) => p.upc === key.upc);
+
+        return product
+          ? {
+              id: product.id,
+              name: product.name,
+              upc: product.upc,
+              price: product.price,
+            }
+          : null;
+      },
+    },
+  },
+});

--- a/src/test-cases/fed1-external-extends-resolvable/data.ts
+++ b/src/test-cases/fed1-external-extends-resolvable/data.ts
@@ -1,0 +1,9 @@
+export const products = [
+  {
+    id: "p1",
+    pid: "p1-pid",
+    price: 12.3,
+    upc: "upc1",
+    name: "p1-name",
+  },
+];

--- a/src/test-cases/fed1-external-extends-resolvable/index.ts
+++ b/src/test-cases/fed1-external-extends-resolvable/index.ts
@@ -1,0 +1,6 @@
+import { serve } from "../../supergraph";
+import a from "./a.subgraph";
+import b from "./b.subgraph";
+import tests from "./test";
+
+export default serve("fed1-external-extends-resolvable", [a, b], tests);

--- a/src/test-cases/fed1-external-extends-resolvable/test.ts
+++ b/src/test-cases/fed1-external-extends-resolvable/test.ts
@@ -1,0 +1,69 @@
+import { createTest } from "../../test";
+
+export default [
+  createTest(
+    /* GraphQL */ `
+      query {
+        productInA {
+          id
+          pid
+          price
+          upc
+          name
+        }
+      }
+    `,
+    {
+      data: {
+        productInA: {
+          id: "p1",
+          pid: "p1-pid",
+          price: 12.3,
+          upc: "upc1",
+          name: "p1-name",
+        },
+      },
+    },
+    /* GraphQL */ `
+    QueryPlan {
+      Sequence {
+        Fetch(service: "a") {
+          {
+            productInA {
+              __typename
+              id
+              name
+              pid
+            }
+          }
+        },
+        Flatten(path: "productInA") {
+          Fetch(service: "b") {
+            {
+              ... on Product {
+                __typename
+                # NOTE
+                # The "id" and "name" fields are available in subgraph A
+                # and are needed to resolve the reference in subgraph B.
+                # What we check here is if the gateway can resolve "upc".
+                # It is marked as external, and it is part of the key fields,
+                # but other set of key fields was used.
+                # It means that you only need to fulfil one set of key fields,
+                # to resolve every field in the type.
+                id
+                name
+              }
+            } =>
+            {
+              ... on Product {
+                price
+                upc
+              }
+            }
+          },
+        },
+      },
+    }
+    `
+  ),
+];


### PR DESCRIPTION
The "id" and "name" fields are available in subgraph A and are needed to resolve the reference in subgraph B.
What we check here is if the gateway can resolve "upc".
It is marked as external, and it is part of the key fields, but other set of key fields was used to make the entity call.
This test proves that you only need to fulfil one set of key fields, to resolve any field in the type.