### PR TITLE
Add resolved-object-in-resolve-ref test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import unionInterfaceDistributed from "./test-cases/union-interface-distributed"
 import mutations from "./test-cases/mutations";
 import abstractTypes from "./test-cases/abstract-types";
 import fed1ExternalExtendsResolvable from "./test-cases/fed1-external-extends-resolvable";
+import resolvedObjectInResolveRef from "./test-cases/resolved-object-in-resolve-ref";
 import { Env } from "./env";
 
 const testCases = [
@@ -76,6 +77,7 @@ const testCases = [
   includeSkip,
   circularReferenceInterface,
   typename,
+  resolvedObjectInResolveRef,
 ];
 
 function routerFetch(

--- a/src/test-cases/resolved-object-in-resolve-ref/a.subgraph.ts
+++ b/src/test-cases/resolved-object-in-resolve-ref/a.subgraph.ts
@@ -1,0 +1,36 @@
+import { createSubgraph } from "../../subgraph";
+import { data } from "./data";
+
+export default createSubgraph("a", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.5", import: ["@key"])
+
+    type TypeA
+      @key(fields: "id", resolvable: true)
+      @key(fields: "pId", resolvable: false)
+      @key(fields: "compositeId { one two }", resolvable: false)
+      @key(fields: "id compositeId { two three }", resolvable: false) {
+      id: ID!
+      pId: ID!
+      compositeId: TypeACompositeID!
+      name: String!
+    }
+
+    type TypeACompositeID {
+      one: ID!
+      two: ID!
+      three: ID!
+    }
+  `,
+  resolvers: {
+    TypeA: {
+      __resolveReference: (reference: { id: string }) => {
+        return data.a[reference.id];
+      },
+      name: ({ name }: { id: string; name: string }) => {
+        return name;
+      },
+    },
+  },
+});

--- a/src/test-cases/resolved-object-in-resolve-ref/b.subgraph.ts
+++ b/src/test-cases/resolved-object-in-resolve-ref/b.subgraph.ts
@@ -1,0 +1,67 @@
+import { createSubgraph } from "../../subgraph";
+import { data } from "./data";
+
+export default createSubgraph("b", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.5"
+        import: ["@key", "@requires", "@external"]
+      )
+
+    type Query {
+      b: TypeB
+    }
+
+    type TypeB @key(fields: "id") {
+      id: ID!
+      favouriteTypeAs: [TypeA!]!
+    }
+
+    type TypeA
+      @key(fields: "compositeId { one two }", resolvable: false)
+      @key(fields: "id compositeId { two three }", resolvable: true)
+      @key(fields: "pId", resolvable: false)
+      @key(fields: "id", resolvable: false) {
+      id: ID!
+      pId: ID!
+      compositeId: TypeACompositeID!
+      name: String! @external
+      nameInTypeB: String! @requires(fields: "name")
+    }
+
+    type TypeACompositeID {
+      one: ID!
+      two: ID!
+      three: ID!
+    }
+  `,
+  resolvers: {
+    Query: {
+      b: () => {
+        return data.b["100"];
+      },
+    },
+    TypeB: {
+      favouriteTypeAs: ({ favouriteAs }: { favouriteAs: string[] }) => {
+        return favouriteAs.map((id) => ({
+          id,
+          pId: `p:${id}`,
+          compositeId: {
+            one: `from TypeB - compositeId - 1: ${id}`,
+            two: `from TypeB - compositeId - 2: ${id}`,
+            three: `from TypeB - compositeId - 3: ${id}`,
+          },
+        }));
+      },
+    },
+    TypeA: {
+      __resolveReference: (reference: unknown) => {
+        return reference;
+      },
+      nameInTypeB: ({ name }: { name: string }) => {
+        return `b.TypeA.nameInTypeB ${name}`;
+      },
+    },
+  },
+});

--- a/src/test-cases/resolved-object-in-resolve-ref/data.ts
+++ b/src/test-cases/resolved-object-in-resolve-ref/data.ts
@@ -1,0 +1,13 @@
+export const data: {
+  a: Record<string, { id: string; name: string }>;
+  b: Record<string, { id: string; favouriteAs: string[] }>;
+} = {
+  a: {
+    "1": { id: "1", name: "a.1" },
+    "2": { id: "2", name: "a.2" },
+  },
+  b: {
+    "100": { id: "100", favouriteAs: ["1"] },
+    "200": { id: "200", favouriteAs: ["1", "2"] },
+  },
+};

--- a/src/test-cases/resolved-object-in-resolve-ref/index.ts
+++ b/src/test-cases/resolved-object-in-resolve-ref/index.ts
@@ -1,0 +1,6 @@
+import { serve } from "../../supergraph";
+import a from "./a.subgraph";
+import b from "./b.subgraph";
+import test from "./test";
+
+export default serve("resolved-object-in-resolve-ref", [a, b], test);

--- a/src/test-cases/resolved-object-in-resolve-ref/test.ts
+++ b/src/test-cases/resolved-object-in-resolve-ref/test.ts
@@ -1,0 +1,32 @@
+import { createTest } from "../../test";
+
+export default [
+  createTest(
+    /* GraphQL */ `
+      query {
+        b {
+          id
+          favouriteTypeAs {
+            id
+            name
+            nameInTypeB
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        b: {
+          id: "100",
+          favouriteTypeAs: [
+            {
+              id: "1",
+              name: "a.1",
+              nameInTypeB: "b.TypeA.nameInTypeB a.1",
+            },
+          ],
+        },
+      },
+    }
+  ),
+];


### PR DESCRIPTION
This PR adds an observed behaviour where a subgraph may pick the first `@key` on an object, even if it's marked as `resolvable: false` in certain scenario:

1. if a subgraph already resolved an object...
2. then moves to another subgraph to resolve a field...
3. that is marked as `@external` in the original subgraph...
4. so, it can resolve a `@requires` field in the original subgraph

Or... at least this is what happens in my head 🙂

The following screenshot shows the reference the original subgraph would receive keys declared in the first `@key` even when it's not resolvable:

<img width="575" alt="Screenshot 2024-06-06 at 10 19 14 pm" src="https://github.com/the-guild-org/federation-compatibility/assets/33769523/3f65968d-361b-4b20-9b6c-a25bfb1f9f2f">
