### PR TITLE
Export server/router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "graphql-federation-gateway-audit",
-  "version": "1.0.0",
+  "name": "@the-guild/graphql-federation-gateway-audit",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "graphql-federation-gateway-audit",
-      "version": "1.0.0",
+      "name": "@the-guild/graphql-federation-gateway-audit",
+      "version": "0.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "graphql-federation-gateway-audit",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@apollo/composition": "2.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "async-retry": "1.3.3",
         "detect-port": "1.6.1",
         "dotenv": "16.4.5",
-        "fets": "0.8.3",
+        "fets": "0.8.4",
         "get-port": "7.1.0",
         "graphql": "16.9.0",
         "graphql-yoga": "5.10.2",
@@ -1465,8 +1465,7 @@
     "node_modules/@kamilkisiela/fast-url-parser": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
-      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
-      "license": "MIT"
+      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew=="
     },
     "node_modules/@npmcli/fs": {
       "version": "3.1.1",
@@ -2359,12 +2358,11 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.9.23",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.23.tgz",
-      "integrity": "sha512-7xlqWel9JsmxahJnYVUj/LLxWcnA93DR4c9xlw3U814jWTiYalryiH1qToik1hOxweKKRLi4haXHM5ycRksPBA==",
-      "license": "MIT",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.1.tgz",
+      "integrity": "sha512-gmPOLrsjSZWEZlr9Oe5+wWFBq3CG6fN13rGlM91Jsj/vZ95G9CCvrORGBAxMXy0AJGiC83aYiHXn3JzTzXQmbA==",
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.6.0",
+        "@whatwg-node/node-fetch": "^0.7.1",
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
@@ -2372,10 +2370,9 @@
       }
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.6.0.tgz",
-      "integrity": "sha512-tcZAhrpx6oVlkEsRngeTEEE7I5/QdLjeEz4IlekabGaESP7+Dkm/6a9KcF1KdCBB7mO9PXtBkwCuTCt8+UPg8Q==",
-      "license": "MIT",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.2.tgz",
+      "integrity": "sha512-OAAEIbyspvQwkcRGutYN3D0a+hzQogvcZ7I3hf6vg742ZEq52yMJTGtkwjl3KZRmzzUltd/oEMxEGsXFLjnuLQ==",
       "dependencies": {
         "@kamilkisiela/fast-url-parser": "^1.1.4",
         "busboy": "^1.6.0",
@@ -2393,34 +2390,6 @@
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/fetch": "^0.10.0",
-        "tslib": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@whatwg-node/server/node_modules/@whatwg-node/fetch": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.1.tgz",
-      "integrity": "sha512-gmPOLrsjSZWEZlr9Oe5+wWFBq3CG6fN13rGlM91Jsj/vZ95G9CCvrORGBAxMXy0AJGiC83aYiHXn3JzTzXQmbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@whatwg-node/node-fetch": "^0.7.1",
-        "urlpattern-polyfill": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@whatwg-node/server/node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.2.tgz",
-      "integrity": "sha512-OAAEIbyspvQwkcRGutYN3D0a+hzQogvcZ7I3hf6vg742ZEq52yMJTGtkwjl3KZRmzzUltd/oEMxEGsXFLjnuLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@kamilkisiela/fast-url-parser": "^1.1.4",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
         "tslib": "^2.6.3"
       },
       "engines": {
@@ -4473,14 +4442,12 @@
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "license": "MIT"
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -4506,15 +4473,14 @@
       }
     },
     "node_modules/fets": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/fets/-/fets-0.8.3.tgz",
-      "integrity": "sha512-zWg3VVwf11nn9hX+VTEr/qu2ZnU8QW6kGuJ02qqdBQ9mxb8qhqEYX+zih8UXZHz/uh1T4wYBborPC8hfyuzF3A==",
-      "license": "MIT",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/fets/-/fets-0.8.4.tgz",
+      "integrity": "sha512-0UGMw8+wC/mvWUUMDLsGYgYV8AClkQaDMoEUmlAglgP66JcitB8h4rEQEMxOIbkv3/825CNCE22rlSMvOAkPlw==",
       "dependencies": {
-        "@sinclair/typebox": "^0.33.0",
+        "@sinclair/typebox": "^0.34.0",
         "@whatwg-node/cookie-store": "^0.2.0",
-        "@whatwg-node/fetch": "^0.9.4",
-        "@whatwg-node/server": "^0.9.15",
+        "@whatwg-node/fetch": "^0.10.0",
+        "@whatwg-node/server": "^0.9.55",
         "hotscript": "^1.0.11",
         "json-schema-to-ts": "^3.0.0",
         "qs": "^6.11.2",
@@ -4526,10 +4492,9 @@
       }
     },
     "node_modules/fets/node_modules/@sinclair/typebox": {
-      "version": "0.33.12",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.12.tgz",
-      "integrity": "sha512-d5KrXIdPolLp8VpGpZAQvEz8ioVtFlUQSyCIS2sEBi7FKhceIB7nj9BlNfqqvp5wmOfg8v8bP1rAvYYkjz21/Q==",
-      "license": "MIT"
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.0.tgz",
+      "integrity": "sha512-BwY8C9W0/LP34i0Nzj0Xj2My0a7vBA1JGC7G0NxvQBBdHyXBf1ar27d79drRdhkgdlLhcyEpQHJKdpdoxZd+tA=="
     },
     "node_modules/file-type": {
       "version": "5.2.0",
@@ -4892,34 +4857,6 @@
       },
       "peerDependencies": {
         "graphql": "^15.2.0 || ^16.0.0"
-      }
-    },
-    "node_modules/graphql-yoga/node_modules/@whatwg-node/fetch": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.1.tgz",
-      "integrity": "sha512-gmPOLrsjSZWEZlr9Oe5+wWFBq3CG6fN13rGlM91Jsj/vZ95G9CCvrORGBAxMXy0AJGiC83aYiHXn3JzTzXQmbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@whatwg-node/node-fetch": "^0.7.1",
-        "urlpattern-polyfill": "^10.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/graphql-yoga/node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.2.tgz",
-      "integrity": "sha512-OAAEIbyspvQwkcRGutYN3D0a+hzQogvcZ7I3hf6vg742ZEq52yMJTGtkwjl3KZRmzzUltd/oEMxEGsXFLjnuLQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@kamilkisiela/fast-url-parser": "^1.1.4",
-        "busboy": "^1.6.0",
-        "fast-querystring": "^1.1.1",
-        "tslib": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/graphql-yoga/node_modules/lru-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@the-guild/graphql-federation-gateway-audit",
-  "version": "0.0.1",
+  "name": "graphql-federation-gateway-audit",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@the-guild/graphql-federation-gateway-audit",
-      "version": "0.0.1",
+      "name": "graphql-federation-gateway-audit",
+      "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
-    "postinstall": "npm run build"
+    "postinstall": "npm run build --noCheck"
   },
   "dependencies": {
     "@apollo/composition": "2.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "graphql-federation-gateway-audit",
-  "version": "1.0.0",
+  "name": "@the-guild/graphql-federation-gateway-audit",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "Audit tool for Apollo Federation Gateway",
@@ -39,8 +39,7 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
-    "access": "public",
-    "directory": "dist"
+    "access": "public"
   },
   "sideEffects": false,
   "scripts": {
@@ -49,7 +48,7 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "format": "prettier --write .",
-    "postinstall": "npm run build --noCheck"
+    "postinstall": "npx tsc --project tsconfig.json --noCheck --noResolve"
   },
   "dependencies": {
     "@apollo/composition": "2.9.3",
@@ -78,7 +77,7 @@
     "express": "5.0.1",
     "prettier": "3.3.3",
     "tsx": "4.19.2",
-    "typescript": "5.6.3",
-    "wgc": "0.70.1"
+    "wgc": "0.70.1",
+    "typescript": "5.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",
-    "access": "public"
+    "access": "public",
+    "directory": "dist"
   },
   "sideEffects": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "summary": "tsx ./src/summary.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "@apollo/composition": "2.9.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@apollo/subgraph": "2.9.3",
     "async-retry": "1.3.3",
     "dotenv": "16.4.5",
-    "fets": "0.8.3",
+    "fets": "0.8.4",
     "get-port": "7.1.0",
     "graphql": "16.9.0",
     "graphql-yoga": "5.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@the-guild/graphql-federation-gateway-audit",
-  "version": "0.0.1",
+  "name": "graphql-federation-gateway-audit",
+  "version": "1.0.0",
   "private": true,
   "type": "module",
   "description": "Audit tool for Apollo Federation Gateway",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,171 +1,56 @@
-import { createRouter, Response } from "fets";
+import { createRouter as createFetsRouter, Response } from "fets";
 import { createServer } from "node:http";
 
-const testCases = await Promise.all(
-  [
-    import("./test-suites/union-intersection/index.js"),
-    import("./test-suites/simple-entity-call/index.js"),
-    import("./test-suites/complex-entity-call/index.js"),
-    import("./test-suites/mysterious-external/index.js"),
-    import("./test-suites/simple-requires-provides/index.js"),
-    import("./test-suites/override-type-interface/index.js"),
-    import("./test-suites/simple-interface-object/index.js"),
-    import("./test-suites/simple-override/index.js"),
-    import("./test-suites/unavailable-override/index.js"),
-    import("./test-suites/override-with-requires/index.js"),
-    import("./test-suites/node/index.js"),
-    import("./test-suites/simple-inaccessible/index.js"),
-    import("./test-suites/enum-intersection/index.js"),
-    import("./test-suites/input-object-intersection/index.js"),
-    import("./test-suites/requires-with-fragments/index.js"),
-    import("./test-suites/child-type-mismatch/index.js"),
-    import("./test-suites/non-resolvable-interface-object/index.js"),
-    import("./test-suites/interface-object-with-requires/index.js"),
-    import("./test-suites/requires-interface/index.js"),
-    import("./test-suites/fed1-external-extends/index.js"),
-    import("./test-suites/fed2-external-extends/index.js"),
-    import("./test-suites/fed1-external-extension/index.js"),
-    import("./test-suites/fed2-external-extension/index.js"),
-    import("./test-suites/parent-entity-call/index.js"),
-    import("./test-suites/corrupted-supergraph-node-id/index.js"),
-    import("./test-suites/parent-entity-call-complex/index.js"),
-    import("./test-suites/shared-root/index.js"),
-    import("./test-suites/nested-provides/index.js"),
-    import("./test-suites/provides-on-interface/index.js"),
-    import("./test-suites/provides-on-union/index.js"),
-    import("./test-suites/requires-requires/index.js"),
-    import("./test-suites/include-skip/index.js"),
-    import("./test-suites/circular-reference-interface/index.js"),
-    import("./test-suites/typename/index.js"),
-    import("./test-suites/union-interface-distributed/index.js"),
-    import("./test-suites/mutations/index.js"),
-    import("./test-suites/abstract-types/index.js"),
-    import("./test-suites/fed1-external-extends-resolvable/index.js"),
-    import("./test-suites/requires-with-argument/index.js"),
-    import("./test-suites/keys-mashup/index.js"),
-    import("./test-suites/null-keys/index.js"),
-  ].map((i) => i.then((e) => e.default)),
-);
-
-export function serve(port: number): Promise<void> {
-  const router = createRouter({
-    landingPage: false,
-    swaggerUI: {
-      endpoint: "/",
-      displayOperationId: false,
-    },
-    openAPI: {
-      info: {
-        title: "Federation Compatibility Test Suite",
-        description:
-          "A test suite for validating Apollo Federation v2 compatibility",
-        contact: {
-          name: "The Guild",
-          url: "https://the-guild.dev",
-          email: "contact@the-guild.dev",
-        },
-      },
-    },
-  });
-
-  router.route({
-    method: "GET",
-    path: "/_health",
-    handler() {
-      return new Response("OK");
-    },
-  });
-
-  router.route({
-    method: "GET",
-    path: "/ids",
-    operationId: "get_ids",
-    description: "A list of test cases",
-    tags: ["root"],
-    schemas: {
-      responses: {
-        200: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
-    },
-    handler() {
-      return Response.json(testCases.map((t) => t.id));
-    },
-  });
-
-  router.route({
-    method: "GET",
-    path: "/supergraphs",
-    description: "A list of supergraph endpoints",
-    tags: ["root"],
-    schemas: {
-      responses: {
-        200: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
-    },
-    handler(req) {
-      return Response.json(
-        testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/supergraph`),
-      );
-    },
-  });
-
-  router.route({
-    method: "GET",
-    path: "/tests",
-    description: "A list of endpoints with tests",
-    tags: ["root"],
-    schemas: {
-      responses: {
-        200: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
-    },
-    handler(req) {
-      return Response.json(
-        testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/tests`),
-      );
-    },
-  });
-
-  router.route({
-    method: "GET",
-    path: "/subgraphs",
-    description: "A list of endpoints with subgraphs",
-    tags: ["root"],
-    schemas: {
-      responses: {
-        200: {
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
-    },
-    handler(req) {
-      return Response.json(
-        testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/subgraphs`),
-      );
-    },
-  });
+async function getTestCases(router: ReturnType<typeof createRouter>) {
+  const testCases = await Promise.all(
+    [
+      import("./test-suites/union-intersection/index.js"),
+      import("./test-suites/simple-entity-call/index.js"),
+      import("./test-suites/complex-entity-call/index.js"),
+      import("./test-suites/mysterious-external/index.js"),
+      import("./test-suites/simple-requires-provides/index.js"),
+      import("./test-suites/override-type-interface/index.js"),
+      import("./test-suites/simple-interface-object/index.js"),
+      import("./test-suites/simple-override/index.js"),
+      import("./test-suites/unavailable-override/index.js"),
+      import("./test-suites/override-with-requires/index.js"),
+      import("./test-suites/node/index.js"),
+      import("./test-suites/simple-inaccessible/index.js"),
+      import("./test-suites/enum-intersection/index.js"),
+      import("./test-suites/input-object-intersection/index.js"),
+      import("./test-suites/requires-with-fragments/index.js"),
+      import("./test-suites/child-type-mismatch/index.js"),
+      import("./test-suites/non-resolvable-interface-object/index.js"),
+      import("./test-suites/interface-object-with-requires/index.js"),
+      import("./test-suites/requires-interface/index.js"),
+      import("./test-suites/fed1-external-extends/index.js"),
+      import("./test-suites/fed2-external-extends/index.js"),
+      import("./test-suites/fed1-external-extension/index.js"),
+      import("./test-suites/fed2-external-extension/index.js"),
+      import("./test-suites/parent-entity-call/index.js"),
+      import("./test-suites/corrupted-supergraph-node-id/index.js"),
+      import("./test-suites/parent-entity-call-complex/index.js"),
+      import("./test-suites/shared-root/index.js"),
+      import("./test-suites/nested-provides/index.js"),
+      import("./test-suites/provides-on-interface/index.js"),
+      import("./test-suites/provides-on-union/index.js"),
+      import("./test-suites/requires-requires/index.js"),
+      import("./test-suites/include-skip/index.js"),
+      import("./test-suites/circular-reference-interface/index.js"),
+      import("./test-suites/typename/index.js"),
+      import("./test-suites/union-interface-distributed/index.js"),
+      import("./test-suites/mutations/index.js"),
+      import("./test-suites/abstract-types/index.js"),
+      import("./test-suites/fed1-external-extends-resolvable/index.js"),
+      import("./test-suites/requires-with-argument/index.js"),
+      import("./test-suites/keys-mashup/index.js"),
+      import("./test-suites/null-keys/index.js"),
+    ].map((i) => i.then((e) => e.default))
+  );
 
   testCases.sort((a, b) => a.id.localeCompare(b.id));
 
-  let registeredNames = new Set<string>();
+  const registeredNames = new Set<string>();
 
   for (const testCase of testCases) {
     if (registeredNames.has(testCase.id)) {
@@ -176,17 +61,21 @@ export function serve(port: number): Promise<void> {
     testCase.createRoutes(router);
   }
 
-  router.route({
-    path: "*",
-    handler: () => new Response("Not found", { status: 404 }),
-  });
+  return testCases;
+}
 
-  const { resolve, reject, promise } = Promise.withResolvers<void>();
+export function serve(port: number) {
+  const router = createRouter();
+  const { resolve, reject, promise } = Promise.withResolvers<{
+    close: VoidFunction;
+  }>();
 
   let started = false;
   const server = createServer(router).listen(port, () => {
     started = true;
-    resolve();
+    resolve({
+      close,
+    });
   });
 
   server.once("error", (error) => {
@@ -199,7 +88,16 @@ export function serve(port: number): Promise<void> {
 
   function close() {
     if (server.listening) {
-      server.close();
+      return new Promise<void>((resolve, reject) => {
+        server.closeAllConnections();
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      })
     }
   }
 
@@ -220,4 +118,128 @@ export function serve(port: number): Promise<void> {
   });
 
   return promise;
+}
+
+export function createRouter() {
+  const router = createFetsRouter({
+    landingPage: false,
+    swaggerUI: {
+      endpoint: "/",
+      displayOperationId: false,
+    },
+    openAPI: {
+      info: {
+        title: "Federation Compatibility Test Suite",
+        description:
+          "A test suite for validating Apollo Federation v2 compatibility",
+        contact: {
+          name: "The Guild",
+          url: "https://the-guild.dev",
+          email: "contact@the-guild.dev",
+        },
+      },
+    },
+  })
+    .route({
+      method: "GET",
+      path: "/_health",
+      handler() {
+        return new Response("OK");
+      },
+    })
+    .route({
+      method: "GET",
+      path: "/ids",
+      operationId: "get_ids",
+      description: "A list of test cases",
+      tags: ["root"],
+      schemas: {
+        responses: {
+          200: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+      handler() {
+        return testCases$.then((testCases) =>
+          Response.json(testCases.map((t) => t.id))
+        );
+      },
+    })
+    .route({
+      method: "GET",
+      path: "/supergraphs",
+      description: "A list of supergraph endpoints",
+      tags: ["root"],
+      schemas: {
+        responses: {
+          200: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+      handler(req) {
+        return testCases$.then((testCases) =>
+          Response.json(
+            testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/supergraph`)
+          )
+        );
+      },
+    })
+    .route({
+      method: "GET",
+      path: "/tests",
+      description: "A list of endpoints with tests",
+      tags: ["root"],
+      schemas: {
+        responses: {
+          200: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+      handler(req) {
+        return testCases$.then((testCases) =>
+          Response.json(
+            testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/tests`)
+          )
+        );
+      },
+    })
+    .route({
+      method: "GET",
+      path: "/subgraphs",
+      description: "A list of endpoints with subgraphs",
+      tags: ["root"],
+      schemas: {
+        responses: {
+          200: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+      handler(req) {
+        return testCases$.then((testCases) =>
+          Response.json(
+            testCases.map(({ id }) => `${req.parsedUrl.origin}/${id}/subgraphs`)
+          )
+        );
+      },
+    });
+
+  const testCases$ = getTestCases(router);
+
+  return router;
 }

--- a/src/subgraph.ts
+++ b/src/subgraph.ts
@@ -57,8 +57,8 @@ export function createSubgraph(
             },
           },
         },
-        async handler(req) {
-          return lazyYoga().fetch(req, { env }) as Promise<Response>;
+        handler(req) {
+          return lazyYoga()(req, { env }) as Promise<Response>;
         },
       });
 
@@ -102,8 +102,8 @@ export function createSubgraph(
             },
           },
         },
-        async handler(req) {
-          return lazyYoga().fetch(req, { env }) as Promise<any>;
+        handler(req) {
+          return lazyYoga()(req, { env }) as Promise<any>;
         },
       });
     },

--- a/src/supergraph.ts
+++ b/src/supergraph.ts
@@ -53,7 +53,7 @@ export function serve(
         subgraph.createRoutes(id, router);
       }
 
-      async function serveSupergraph(request: { url: string; parsedUrl: URL }) {
+      function serveSupergraph(request: { url: string; parsedUrl: URL }) {
         const supergraph = getSupergraph(
           subgraphs.map((subgraph) => ({
             name: subgraph.name,

--- a/src/test-suites/keys-mashup/a.subgraph.ts
+++ b/src/test-suites/keys-mashup/a.subgraph.ts
@@ -1,5 +1,5 @@
-import { createSubgraph } from "../../subgraph";
-import { data } from "./data";
+import { createSubgraph } from "../../subgraph.js";
+import { data } from "./data.js";
 
 export default createSubgraph("a", {
   typeDefs: /* GraphQL */ `

--- a/src/test-suites/keys-mashup/b.subgraph.ts
+++ b/src/test-suites/keys-mashup/b.subgraph.ts
@@ -1,5 +1,5 @@
-import { createSubgraph } from "../../subgraph";
-import { data } from "./data";
+import { createSubgraph } from "../../subgraph.js";
+import { data } from "./data.js";
 
 export default createSubgraph("b", {
   typeDefs: /* GraphQL */ `

--- a/src/test-suites/keys-mashup/index.ts
+++ b/src/test-suites/keys-mashup/index.ts
@@ -1,4 +1,4 @@
-import { serve } from "../../supergraph";
+import { serve } from "../../supergraph.js";
 import a from "./a.subgraph.js";
 import b from "./b.subgraph.js";
 import test from "./test.js";

--- a/src/test-suites/keys-mashup/test.ts
+++ b/src/test-suites/keys-mashup/test.ts
@@ -1,4 +1,4 @@
-import { createTest } from "../../testkit";
+import { createTest } from "../../testkit.js";
 
 export default [
   createTest(

--- a/src/test-suites/node/test.ts
+++ b/src/test-suites/node/test.ts
@@ -1,4 +1,4 @@
-import { createTest } from "../../testkit";
+import { createTest } from "../../testkit.js";
 
 export default [
   createTest(


### PR DESCRIPTION
- Export `createRouter` by exporting the HTTP handler so we can use `fetch` function from it inside tests without starting a real server
- Export `close` method in the return value of `serve` so we can use start and stop server
- Avoid top-level await for better support in most envs
- In case of `npm install` from another project, it runs `tsc` to generate js and declaration files to be used in our Hive GW test suite here;
https://github.com/graphql-hive/gateway/pull/120