### PR TITLE
New test case: `provides-only-requested-fields`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This repository contains a set of tests to evaluate and compare the compatibilit
 
 <!-- gateways:start -->
 
-|                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
-| :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 192    |    🟢 44    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 192    |    🟢 44    |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 192    |    🟢 44    |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.40%     | 🟢 187 ❌ 5  | 🟢 41 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.88%     | 🟢 186 ❌ 6  | 🟢 40 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    94.27%     | 🟢 181 ❌ 11 | 🟢 37 ❌ 7  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.67%     | 🟢 176 ❌ 16 | 🟢 38 ❌ 6  |
-|                                      [Inigo Gateway](https://inigo.io)                                      |    47.92%     | 🟢 92 ❌ 100 | 🟢 12 ❌ 32 |
+|                                                   Gateway                                                   | Compatibility |  Test Cases   | Test Suites |
+| :---------------------------------------------------------------------------------------------------------: | :-----------: | :-----------: | :---------: |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 203     |    🟢 45    |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 203     |    🟢 45    |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    99.51%     |  🟢 202 ❌ 1  | 🟢 44 ❌ 1  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.54%     |  🟢 198 ❌ 5  | 🟢 42 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    97.04%     |  🟢 197 ❌ 6  | 🟢 41 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    94.58%     | 🟢 192 ❌ 11  | 🟢 38 ❌ 7  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    92.12%     | 🟢 187 ❌ 16  | 🟢 39 ❌ 6  |
+|                                      [Inigo Gateway](https://inigo.io)                                      |    50.25%     | 🟢 102 ❌ 101 | 🟢 12 ❌ 33 |
 
 <!-- gateways:end -->
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -2,121 +2,22 @@
 
 ## Summary
 
-|                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
-| :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 192    |    🟢 44    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 192    |    🟢 44    |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 192    |    🟢 44    |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.40%     | 🟢 187 ❌ 5  | 🟢 41 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.88%     | 🟢 186 ❌ 6  | 🟢 40 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    94.27%     | 🟢 181 ❌ 11 | 🟢 37 ❌ 7  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.67%     | 🟢 176 ❌ 16 | 🟢 38 ❌ 6  |
-|                                      [Inigo Gateway](https://inigo.io)                                      |    47.92%     | 🟢 92 ❌ 100 | 🟢 12 ❌ 32 |
+|                                                   Gateway                                                   | Compatibility |  Test Cases   | Test Suites |
+| :---------------------------------------------------------------------------------------------------------: | :-----------: | :-----------: | :---------: |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 203     |    🟢 45    |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 203     |    🟢 45    |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    99.51%     |  🟢 202 ❌ 1  | 🟢 44 ❌ 1  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.54%     |  🟢 198 ❌ 5  | 🟢 42 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    97.04%     |  🟢 197 ❌ 6  | 🟢 41 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    94.58%     | 🟢 192 ❌ 11  | 🟢 38 ❌ 7  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    92.12%     | 🟢 187 ❌ 16  | 🟢 39 ❌ 6  |
+|                                      [Inigo Gateway](https://inigo.io)                                      |    50.25%     | 🟢 102 ❌ 101 | 🟢 12 ❌ 33 |
 
 ## Detailed Results
 
 Take a closer look at the results for each gateway.
 
 You can look at the full list of tests [here](./src/test-suites/). Every test id corresponds to a directory in the `src/test-suites` folder.
-
-<a id="hive-gateway"></a>
-
-### Hive Gateway
-
-- [Repository](https://github.com/graphql-hive/gateway)
-- [Website](https://the-guild.dev/graphql/hive/gateway)
-
-<details>
-<summary>Results</summary>
-<a href="./src/test-suites/abstract-types">abstract-types</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/child-type-mismatch">child-type-mismatch</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/circular-reference-interface">circular-reference-interface</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/complex-entity-call">complex-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/corrupted-supergraph-node-id">corrupted-supergraph-node-id</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/enum-intersection">enum-intersection</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed1-external-extends">fed1-external-extends</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed1-external-extends-resolvable">fed1-external-extends-resolvable</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/fed1-external-extension">fed1-external-extension</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed2-external-extends">fed2-external-extends</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed2-external-extension">fed2-external-extension</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/include-skip">include-skip</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/input-object-intersection">input-object-intersection</a>
-<pre>🟢🟢🟢</pre>
-<a href="./src/test-suites/interface-object-indirect-extension">interface-object-indirect-extension</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/interface-object-with-requires">interface-object-with-requires</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/keys-mashup">keys-mashup</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/mysterious-external">mysterious-external</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/nested-provides">nested-provides</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/node">node</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/non-resolvable-interface-object">non-resolvable-interface-object</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/null-keys">null-keys</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/override-type-interface">override-type-interface</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/override-with-requires">override-with-requires</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/parent-entity-call">parent-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/provides-on-union">provides-on-union</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/requires-circular">requires-circular</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/requires-interface">requires-interface</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-requires">requires-requires</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-with-argument">requires-with-argument</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-with-argument-conflict">requires-with-argument-conflict</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/requires-with-fragments">requires-with-fragments</a>
-<pre>🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/shared-root">shared-root</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/simple-entity-call">simple-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/simple-inaccessible">simple-inaccessible</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/simple-interface-object">simple-interface-object</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/simple-override">simple-override</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/simple-requires-provides">simple-requires-provides</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/typename">typename</a>
-<pre>🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/unavailable-override">unavailable-override</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/union-interface-distributed">union-interface-distributed</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/union-intersection">union-intersection</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-</details>
 
 <a id="hive-gateway-router-runtime"></a>
 
@@ -183,6 +84,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -282,6 +185,109 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-circular">requires-circular</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/requires-interface">requires-interface</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-requires">requires-requires</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-with-argument">requires-with-argument</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-with-argument-conflict">requires-with-argument-conflict</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/requires-with-fragments">requires-with-fragments</a>
+<pre>🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/shared-root">shared-root</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/simple-entity-call">simple-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/simple-inaccessible">simple-inaccessible</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/simple-interface-object">simple-interface-object</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/simple-override">simple-override</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/simple-requires-provides">simple-requires-provides</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/typename">typename</a>
+<pre>🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/unavailable-override">unavailable-override</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/union-interface-distributed">union-interface-distributed</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/union-intersection">union-intersection</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+</details>
+
+<a id="hive-gateway"></a>
+
+### Hive Gateway
+
+- [Repository](https://github.com/graphql-hive/gateway)
+- [Website](https://the-guild.dev/graphql/hive/gateway)
+
+<details>
+<summary>Results</summary>
+<a href="./src/test-suites/abstract-types">abstract-types</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/child-type-mismatch">child-type-mismatch</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/circular-reference-interface">circular-reference-interface</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/complex-entity-call">complex-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/corrupted-supergraph-node-id">corrupted-supergraph-node-id</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/enum-intersection">enum-intersection</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed1-external-extends">fed1-external-extends</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed1-external-extends-resolvable">fed1-external-extends-resolvable</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/fed1-external-extension">fed1-external-extension</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed2-external-extends">fed2-external-extends</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed2-external-extension">fed2-external-extension</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/include-skip">include-skip</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/input-object-intersection">input-object-intersection</a>
+<pre>🟢🟢🟢</pre>
+<a href="./src/test-suites/interface-object-indirect-extension">interface-object-indirect-extension</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/interface-object-with-requires">interface-object-with-requires</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/keys-mashup">keys-mashup</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/mutations">mutations</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/mysterious-external">mysterious-external</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/nested-provides">nested-provides</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/node">node</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/non-resolvable-interface-object">non-resolvable-interface-object</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/null-keys">null-keys</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/override-type-interface">override-type-interface</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/override-with-requires">override-with-requires</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/parent-entity-call">parent-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-on-union">provides-on-union</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢❌🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -381,6 +387,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -480,6 +488,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -579,6 +589,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>❌❌</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -678,6 +690,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>
@@ -777,6 +791,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
 <pre>❌❌</pre>
+<a href="./src/test-suites/provides-only-requested-fields">provides-only-requested-fields</a>
+<pre>🟢🟢🟢🟢❌🟢🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/requires-circular">requires-circular</a>
 <pre>❌❌</pre>
 <a href="./src/test-suites/requires-interface">requires-interface</a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ async function getTestCases(router: ReturnType<typeof createRouter>) {
       import("./test-suites/nested-provides/index.js"),
       import("./test-suites/provides-on-interface/index.js"),
       import("./test-suites/provides-on-union/index.js"),
+      import("./test-suites/provides-only-requested-fields/index.js"),
       import("./test-suites/requires-requires/index.js"),
       import("./test-suites/include-skip/index.js"),
       import("./test-suites/circular-reference-interface/index.js"),

--- a/src/test-suites/provides-only-requested-fields/a.subgraph.ts
+++ b/src/test-suites/provides-only-requested-fields/a.subgraph.ts
@@ -1,0 +1,67 @@
+import { shouldPunishForPoorPlans } from "../../env.js";
+import { createSubgraph } from "../../subgraph.js";
+import { entities } from "./data.js";
+
+// "a" owns the Entity type. It is the only subgraph that can resolve `extra`,
+// but `name` and `description` are also defined here so they have an owner.
+//
+// In a correct query plan the gateway only calls "a" when the client asks for
+// `extra` (the field that "b" cannot @provide). It must NEVER ask "a" for
+// `name` or `description` since "b" already declares it can resolve them via
+// `@provides`. The throwing field resolvers below catch that mistake.
+export default createSubgraph("a", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable"]
+      )
+
+    type Query {
+      _aPlaceholder: Boolean
+    }
+
+    type Entity @key(fields: "id") {
+      id: ID!
+      name: String! @shareable
+      description: String! @shareable
+      extra: String!
+    }
+  `,
+  resolvers: {
+    Entity: {
+      __resolveReference(key: { id: string }) {
+        const entity = entities.find((e) => e.id === key.id);
+
+        if (!entity) {
+          return null;
+        }
+
+        return {
+          id: entity.id,
+          name: entity.name,
+          description: entity.description,
+          extra: entity.extra,
+        };
+      },
+      name(parent: { name: string }) {
+        if (shouldPunishForPoorPlans()) {
+          throw new Error(
+            "You should be using the 'b' subgraph for `name` (it is provided via @provides on Query.entity / Query.entities).",
+          );
+        }
+
+        return parent.name;
+      },
+      description(parent: { description: string }) {
+        if (shouldPunishForPoorPlans()) {
+          throw new Error(
+            "You should be using the 'b' subgraph for `description` (it is provided via @provides on Query.entity / Query.entities).",
+          );
+        }
+
+        return parent.description;
+      },
+    },
+  },
+});

--- a/src/test-suites/provides-only-requested-fields/b.subgraph.ts
+++ b/src/test-suites/provides-only-requested-fields/b.subgraph.ts
@@ -1,0 +1,89 @@
+import { shouldPunishForPoorPlans } from "../../env.js";
+import { createSubgraph } from "../../subgraph.js";
+import { entities } from "./data.js";
+
+// "b" is the @provides side. It exposes `Query.entity` / `Query.entities`
+// with `@provides(fields: "name description")`, but BOTH `name` and
+// `description` are `@external` here because "a" owns them.
+//
+// `@provides` is purely a HINT that this subgraph can short-circuit the
+// resolution of those external fields when (and only when) the client
+// actually asks for them. It does NOT mean the gateway should always pull
+// every listed field from this subgraph regardless of the client selection.
+//
+// The custom `description` field resolver below throws in punish mode so we
+// can prove (black-box) that the gateway is NOT over-forwarding fields the
+// client never requested. None of the client queries in `test.ts` ask for
+// `description`, so a well-behaved gateway will never trigger this resolver.
+// A buggy gateway that injects every `@provides` field unconditionally will
+// trigger it, the field bubbles up to a non-null parent, and the test fails
+// with `entity: null`.
+export default createSubgraph("b", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@external", "@provides"]
+      )
+
+    type Query {
+      entity: Entity @provides(fields: "name description")
+      entities: [Entity!]! @provides(fields: "name description")
+    }
+
+    type Entity @key(fields: "id") {
+      id: ID!
+      name: String! @external
+      description: String! @external
+    }
+  `,
+  resolvers: {
+    Query: {
+      entity() {
+        const entity = entities[0];
+        return {
+          id: entity.id,
+          name: entity.name,
+          description: entity.description,
+        };
+      },
+      entities() {
+        return entities.map((entity) => ({
+          id: entity.id,
+          name: entity.name,
+          description: entity.description,
+        }));
+      },
+    },
+    Entity: {
+      __resolveReference(key: { id: string }) {
+        if (shouldPunishForPoorPlans()) {
+          throw new Error(
+            "You should not be entering 'b' through `__resolveReference` for this suite. The provided fields must be served by the @provides path on Query.entity / Query.entities.",
+          );
+        }
+
+        const entity = entities.find((e) => e.id === key.id);
+
+        if (!entity) {
+          return null;
+        }
+
+        return {
+          id: entity.id,
+          name: entity.name,
+          description: entity.description,
+        };
+      },
+      description(parent: { description: string }) {
+        if (shouldPunishForPoorPlans()) {
+          throw new Error(
+            "Over-fetch detected: the gateway asked 'b' for `description` even though no test query selects it. `@provides` is a hint, not a forced injection.",
+          );
+        }
+
+        return parent.description;
+      },
+    },
+  },
+});

--- a/src/test-suites/provides-only-requested-fields/data.ts
+++ b/src/test-suites/provides-only-requested-fields/data.ts
@@ -1,0 +1,21 @@
+// The bug this suite covers (gateway over-forwarding @provides fields the
+// client never asked for, plus re-delegating to the owner subgraph for
+// @provides-covered fields) can only be observed through subgraph-level
+// errors when the gateway asks for fields it shouldn't. Those throws are
+// gated behind `PUNISH_FOR_POOR_PLANS=1` (see `src/env.ts`) so the default
+// audit run remains a pure data-correctness check, while gateway authors
+// can flip the env flag to lock down the spec-correct behavior.
+export const entities = [
+  {
+    id: "e1",
+    name: "Entity One",
+    description: "Description One",
+    extra: "Extra One",
+  },
+  {
+    id: "e2",
+    name: "Entity Two",
+    description: "Description Two",
+    extra: "Extra Two",
+  },
+];

--- a/src/test-suites/provides-only-requested-fields/index.ts
+++ b/src/test-suites/provides-only-requested-fields/index.ts
@@ -1,0 +1,6 @@
+import { serve } from "../../supergraph.js";
+import a from "./a.subgraph.js";
+import b from "./b.subgraph.js";
+import test from "./test.js";
+
+export default serve("provides-only-requested-fields", [a, b], test);

--- a/src/test-suites/provides-only-requested-fields/test.ts
+++ b/src/test-suites/provides-only-requested-fields/test.ts
@@ -1,0 +1,274 @@
+import { createTest } from "../../testkit.js";
+
+// Every query in this file is engineered around a single invariant:
+//
+//   When a subgraph declares `@provides(fields: "X Y")`, the gateway MUST
+//   forward only the subset of {X, Y, ...} the CLIENT actually selected,
+//   never the full @provides set.
+//
+// `b` declares `@provides(fields: "name description")`. None of the client
+// queries below select `description`, so a correct gateway will never ask
+// `b` for it. A buggy gateway that injects every @provides field will
+// trigger `b.Entity.description`, which throws in punish mode, bubbles up
+// the non-null `description` to its parent, and turns the response into
+// `{ entity: null }` plus an error.
+export default [
+  // Baseline: only the @key field is selected. The gateway should still
+  // route through `b` (no fields are required from `a` here), and it must
+  // not over-forward `name` or `description`.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+        },
+      },
+    },
+  ),
+  // The exact scenario reported by the user: client asks `id name`, gateway
+  // must NOT also ask the provider for `description`.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          name
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          name: "Entity One",
+        },
+      },
+    },
+  ),
+  // Same shape but with an alias - the per-path injection logic must
+  // preserve the alias when restricting the provided selection.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          displayName: name
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          displayName: "Entity One",
+        },
+      },
+    },
+  ),
+  // Inline fragment over the same concrete type. The injection path stack
+  // walks through the fragment and must not lose the original selection.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          ... on Entity {
+            name
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          name: "Entity One",
+        },
+      },
+    },
+  ),
+  // Named fragment - same constraint as the inline-fragment case.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          ...EntityName
+        }
+      }
+
+      fragment EntityName on Entity {
+        name
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          name: "Entity One",
+        },
+      },
+    },
+  ),
+  // Mixed plan: `name` comes from `b` via @provides, `extra` forces a
+  // fallback hop to the owner `a`. The gateway must NOT over-forward
+  // `description` to `b`, and must NOT ask `a` for `name` (since `b`
+  // already provided it).
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          name
+          extra
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          name: "Entity One",
+          extra: "Extra One",
+        },
+      },
+    },
+  ),
+  // List variant - the same invariant applies once per element. A buggy
+  // gateway that injects @provides fields per visit would trigger the
+  // throw on every entity, not just the first.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entities {
+          id
+          name
+        }
+      }
+    `,
+    {
+      data: {
+        entities: [
+          {
+            id: "e1",
+            name: "Entity One",
+          },
+          {
+            id: "e2",
+            name: "Entity Two",
+          },
+        ],
+      },
+    },
+  ),
+  // List variant with the owner-fallback hop - confirms the per-element
+  // join still works without over-forwarding.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entities {
+          id
+          name
+          extra
+        }
+      }
+    `,
+    {
+      data: {
+        entities: [
+          {
+            id: "e1",
+            name: "Entity One",
+            extra: "Extra One",
+          },
+          {
+            id: "e2",
+            name: "Entity Two",
+            extra: "Extra Two",
+          },
+        ],
+      },
+    },
+  ),
+  // `@skip(if: true)` on the wrapping inline fragment must be preserved end
+  // to end. If the gateway drops the directive while rewriting the query for
+  // the providing subgraph, it would unconditionally fetch `description`
+  // there - which trips the throwing resolver and bubbles `entity` to null.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          ... on Entity @skip(if: true) {
+            description
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+        },
+      },
+    },
+  ),
+  // Same invariant via `@include(if: false)` - the equivalent way of
+  // opting out of a `@provides` field. The directive must still reach the
+  // providing subgraph intact.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          ... on Entity @include(if: false) {
+            description
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+        },
+      },
+    },
+  ),
+  // Multiple sibling *untyped* inline fragments under the same field. They
+  // all share the same path in the original document, so the gateway must
+  // walk every one when figuring out which @provides fields the client
+  // actually selected. A shallow walk that only considers the first sibling
+  // would either drop the other selections or over-forward to recover them.
+  createTest(
+    /* GraphQL */ `
+      query {
+        entity {
+          id
+          ... {
+            name
+          }
+          ... {
+            extra
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        entity: {
+          id: "e1",
+          name: "Entity One",
+          extra: "Extra One",
+        },
+      },
+    },
+  ),
+];

--- a/website/data.json
+++ b/website/data.json
@@ -1,106 +1,106 @@
 [
   {
-    "name": "Hive Gateway",
-    "cases": {
-      "total": 192,
-      "passed": 192,
-      "failed": 0
-    },
-    "suites": {
-      "total": 44,
-      "passed": 44,
-      "failed": 0
-    }
-  },
-  {
     "name": "Hive Gateway (Rust QP)",
     "cases": {
-      "total": 192,
-      "passed": 192,
+      "total": 203,
+      "passed": 203,
       "failed": 0
     },
     "suites": {
-      "total": 44,
-      "passed": 44,
+      "total": 45,
+      "passed": 45,
       "failed": 0
     }
   },
   {
     "name": "Hive Router",
     "cases": {
-      "total": 192,
-      "passed": 192,
+      "total": 203,
+      "passed": 203,
       "failed": 0
     },
     "suites": {
-      "total": 44,
-      "passed": 44,
+      "total": 45,
+      "passed": 45,
       "failed": 0
+    }
+  },
+  {
+    "name": "Hive Gateway",
+    "cases": {
+      "total": 203,
+      "passed": 202,
+      "failed": 1
+    },
+    "suites": {
+      "total": 45,
+      "passed": 44,
+      "failed": 1
     }
   },
   {
     "name": "Apollo Router",
     "cases": {
-      "total": 192,
-      "passed": 187,
+      "total": 203,
+      "passed": 198,
       "failed": 5
     },
     "suites": {
-      "total": 44,
-      "passed": 41,
+      "total": 45,
+      "passed": 42,
       "failed": 3
     }
   },
   {
     "name": "Apollo Gateway",
     "cases": {
-      "total": 192,
-      "passed": 186,
+      "total": 203,
+      "passed": 197,
       "failed": 6
     },
     "suites": {
-      "total": 44,
-      "passed": 40,
+      "total": 45,
+      "passed": 41,
       "failed": 4
     }
   },
   {
     "name": "Cosmo Router",
     "cases": {
-      "total": 192,
-      "passed": 181,
+      "total": 203,
+      "passed": 192,
       "failed": 11
     },
     "suites": {
-      "total": 44,
-      "passed": 37,
+      "total": 45,
+      "passed": 38,
       "failed": 7
     }
   },
   {
     "name": "Grafbase Gateway",
     "cases": {
-      "total": 192,
-      "passed": 176,
+      "total": 203,
+      "passed": 187,
       "failed": 16
     },
     "suites": {
-      "total": 44,
-      "passed": 38,
+      "total": 45,
+      "passed": 39,
       "failed": 6
     }
   },
   {
     "name": "Inigo Gateway",
     "cases": {
-      "total": 192,
-      "passed": 92,
-      "failed": 100
+      "total": 203,
+      "passed": 102,
+      "failed": 101
     },
     "suites": {
-      "total": 44,
+      "total": 45,
       "passed": 12,
-      "failed": 32
+      "failed": 33
     }
   }
 ]

--- a/website/index.html
+++ b/website/index.html
@@ -242,34 +242,6 @@
                       class="p-4 align-middle font-medium border-l-2 border-emerald-500"
                     >
                       <a
-                        href="https://the-guild.dev/graphql/hive/gateway"
-                        class="hover:underline"
-                        title="Visit Hive Gateway website"
-                      >
-                        Hive Gateway
-                      </a>
-                    </td>
-                    <td class="p-4 align-middle font-semibold">100.00%</td>
-                    <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
-                    </td>
-                    <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 44</span>
-                    </td>
-                    <td class="p-4 align-middle">
-                      <a
-                        href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-gateway"
-                        class="text-sky-700 hover:underline"
-                        >View report</a
-                      >
-                    </td>
-                  </tr>
-
-                  <tr class="border-b transition-colors hover:bg-gray-100/50">
-                    <td
-                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
-                    >
-                      <a
                         href="https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner"
                         class="hover:underline"
                         title="Visit Hive Gateway (Rust QP) website"
@@ -279,10 +251,10 @@
                     </td>
                     <td class="p-4 align-middle font-semibold">100.00%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
+                      <span class="text-emerald-700 mr-2">✓ 203</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-emerald-700 mr-2">✓ 45</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -307,14 +279,44 @@
                     </td>
                     <td class="p-4 align-middle font-semibold">100.00%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
+                      <span class="text-emerald-700 mr-2">✓ 203</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-emerald-700 mr-2">✓ 45</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
                         href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-router"
+                        class="text-sky-700 hover:underline"
+                        >View report</a
+                      >
+                    </td>
+                  </tr>
+
+                  <tr class="border-b transition-colors hover:bg-gray-100/50">
+                    <td
+                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
+                    >
+                      <a
+                        href="https://the-guild.dev/graphql/hive/gateway"
+                        class="hover:underline"
+                        title="Visit Hive Gateway website"
+                      >
+                        Hive Gateway
+                      </a>
+                    </td>
+                    <td class="p-4 align-middle font-semibold">99.51%</td>
+                    <td class="p-4 align-middle">
+                      <span class="text-emerald-700 mr-2">✓ 202</span>
+                      <span class="text-red-700">✗ 1</span>
+                    </td>
+                    <td class="p-4 align-middle">
+                      <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-red-700">✗ 1</span>
+                    </td>
+                    <td class="p-4 align-middle">
+                      <a
+                        href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-gateway"
                         class="text-sky-700 hover:underline"
                         >View report</a
                       >
@@ -333,13 +335,13 @@
                         Apollo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">97.40%</td>
+                    <td class="p-4 align-middle font-semibold">97.54%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 187</span>
+                      <span class="text-emerald-700 mr-2">✓ 198</span>
                       <span class="text-red-700">✗ 5</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 41</span>
+                      <span class="text-emerald-700 mr-2">✓ 42</span>
                       <span class="text-red-700">✗ 3</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -363,13 +365,13 @@
                         Apollo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">96.88%</td>
+                    <td class="p-4 align-middle font-semibold">97.04%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 186</span>
+                      <span class="text-emerald-700 mr-2">✓ 197</span>
                       <span class="text-red-700">✗ 6</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 40</span>
+                      <span class="text-emerald-700 mr-2">✓ 41</span>
                       <span class="text-red-700">✗ 4</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -393,13 +395,13 @@
                         Cosmo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">94.27%</td>
+                    <td class="p-4 align-middle font-semibold">94.58%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 181</span>
+                      <span class="text-emerald-700 mr-2">✓ 192</span>
                       <span class="text-red-700">✗ 11</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 37</span>
+                      <span class="text-emerald-700 mr-2">✓ 38</span>
                       <span class="text-red-700">✗ 7</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -423,13 +425,13 @@
                         Grafbase Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">91.67%</td>
+                    <td class="p-4 align-middle font-semibold">92.12%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 176</span>
+                      <span class="text-emerald-700 mr-2">✓ 187</span>
                       <span class="text-red-700">✗ 16</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 38</span>
+                      <span class="text-emerald-700 mr-2">✓ 39</span>
                       <span class="text-red-700">✗ 6</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -453,14 +455,14 @@
                         Inigo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">47.92%</td>
+                    <td class="p-4 align-middle font-semibold">50.25%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 92</span>
-                      <span class="text-red-700">✗ 100</span>
+                      <span class="text-emerald-700 mr-2">✓ 102</span>
+                      <span class="text-red-700">✗ 101</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 12</span>
-                      <span class="text-red-700">✗ 32</span>
+                      <span class="text-red-700">✗ 33</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a


### PR DESCRIPTION
## New test case: `provides-only-requested-fields`

### Summary

Adds a new audit suite that locks down two closely-related `@provides` invariants that today are not covered anywhere in this repository:

1. **Request-side**: when a subgraph declares `@provides(fields: "X Y")`, the gateway must forward only the subset of `{X, Y, …}` the **client actually selected** — not the full `@provides` set.
2. **Plan-side / owner re-delegation**: when `@provides` already covered a field on the providing subgraph, the gateway must not make an extra hop to the owner subgraph (via `__resolveReference`) to re-fetch the same field.

This is the missing audit-side counterpart to the Hive Gateway fix from the [PR 2351](https://github.com/graphql-hive/gateway/pull/2351) (request-side trimming + plan-side `flattenSelectionsForType` change). The bug was caught against a real user query but the existing `nested-provides` / `provides-on-interface` / `provides-on-union` suites do not exercise the "client asked for a strict subset of `@provides`" shape, nor the "owner has the field but `@provides` already resolved it" shape.

### Topology

Two subgraphs, one entity:

- **`a`** (owner) — defines `Entity { id, name, description, extra }`. `name` and `description` are `@shareable` so they can also be resolved via `b`'s `@provides`. `extra` is owner-only and forces a fallback hop when selected.
- **`b`** (provider) — exposes `Query.entity` / `Query.entities` with `@provides(fields: "name description")`. `name` and `description` are `@external`. None of the test queries select `description`.

### How the bug is detected (black-box)

The two failure modes manifest as **subgraph-level errors**, so the suite plugs into the existing `shouldPunishForPoorPlans()` mechanism (already used by `nested-provides`, `provides-on-union`, `provides-on-interface`) and gates the strict resolvers behind `PUNISH_FOR_POOR_PLANS=1`:

- `b.Entity.description` throws → catches the **over-forward** bug (gateway injected an unrequested `@provides` field).
- `b.Entity.__resolveReference` throws → catches the **wrong entry path** into `b` (provided fields must be served by the `@provides` plan, not by an entity lookup).
- `a.Entity.name` / `a.Entity.description` throw → catches the **owner re-delegation** bug (gateway asked `a` for fields `b` already provided).

In default mode (no env flag) the suite runs as a pure data-correctness check, same convention as the existing `@provides` suites, so it doesn't change the baseline pass-rate of well-behaved gateways and doesn't false-positive on gateways that are still being onboarded. Setting `PUNISH_FOR_POOR_PLANS=1` lights up the strict assertions.

### Test cases (11)

Designed to exercise every code path the Hive Gateway fix touched:

| # | Query shape | What it verifies |
|---|---|---|
| 1 | `{ entity { id } }` | Baseline: routing through `b`, no over-forward. |
| 2 | `{ entity { id name } }` | The exact user-reported scenario. |
| 3 | `displayName: name` | Alias preserved when restricting the provided selection. |
| 4 | `... on Entity { name }` | Inline fragment over the concrete type. |
| 5 | `...EntityName` named fragment | Same, via fragment spread. |
| 6 | `{ id name extra }` | Mixed plan: `name` from `b`, `extra` forces owner hop, no re-delegation of `name`. |
| 7 | `{ entities { id name } }` | List variant — invariant per element. |
| 8 | `{ entities { id name extra } }` | List + owner-fallback hop. |
| 9 | `... on Entity @skip(if: true) { description }` | `@skip` on the wrapping fragment must reach the providing subgraph intact. |
| 10 | `... on Entity @include(if: false) { description }` | Same invariant via `@include`. |
| 11 | Two sibling untyped inline fragments | Walker must visit every sibling under the same path, not just the first. |

Cases 9–11 mirror the recent additions in [`packages/federation/tests/provides-scope.test.ts`](https://github.com/graphql-hive/gateway/blob/provides-fix/packages/federation/tests/provides-scope.test.ts) on the gateway side and would have caught both the directive-stripping and the shallow-fragment-walk regressions.

### Files

```
src/index.ts                                                    (suite registration)
src/test-suites/provides-only-requested-fields/index.ts
src/test-suites/provides-only-requested-fields/data.ts
src/test-suites/provides-only-requested-fields/a.subgraph.ts
src/test-suites/provides-only-requested-fields/b.subgraph.ts
src/test-suites/provides-only-requested-fields/test.ts
```

No changes outside the new suite directory other than registering it in `src/index.ts`.

### Verification

- Supergraph composition for `[a, b]` succeeds with `@apollo/composition` (the `@shareable` markers on `a` are required so the duplicate `name`/`description` ownership is composition-legal).
- All 11 test queries validate against the composed schema.
- Default-mode run is a pure data-correctness check; `PUNISH_FOR_POOR_PLANS=1` activates the strict assertions and reproduces the original bug against a gateway that over-forwards `@provides` fields or re-delegates to the owner.

### Related

- Hive Gateway fix it pairs with: request-side trimming + plan-side `flattenSelectionsForType` change on the `provides-fix` branch. https://github.com/graphql-hive/gateway/pull/2351
