### PR TITLE
test: new `partial-union` audit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository contains a set of tests to evaluate and compare the compatibilit
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 194    |    🟢 45    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.42%     | 🟢 189 ❌ 5  | 🟢 42 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.91%     | 🟢 188 ❌ 6  | 🟢 41 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.81%     | 🟢 182 ❌ 12 | 🟢 37 ❌ 8  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.75%     | 🟢 178 ❌ 16 | 🟢 39 ❌ 6  |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    98.99%     | 🟢 197 ❌ 2  | 🟢 45 ❌ 1  |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.49%     | 🟢 194 ❌ 5  | 🟢 43 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.98%     | 🟢 193 ❌ 6  | 🟢 42 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    91.96%     | 🟢 183 ❌ 16 | 🟢 37 ❌ 9  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    90.45%     | 🟢 180 ❌ 19 | 🟢 39 ❌ 7  |
 
 <!-- gateways:end -->
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository contains a set of tests to evaluate and compare the compatibilit
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 192    |    🟢 44    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 192    |    🟢 44    |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 192    |    🟢 44    |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.40%     | 🟢 187 ❌ 5  | 🟢 41 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.88%     | 🟢 186 ❌ 6  | 🟢 40 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.75%     | 🟢 180 ❌ 12 | 🟢 36 ❌ 8  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.67%     | 🟢 176 ❌ 16 | 🟢 38 ❌ 6  |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 194    |    🟢 45    |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.42%     | 🟢 189 ❌ 5  | 🟢 42 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.91%     | 🟢 188 ❌ 6  | 🟢 41 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.81%     | 🟢 182 ❌ 12 | 🟢 37 ❌ 8  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.75%     | 🟢 178 ❌ 16 | 🟢 39 ❌ 6  |
 
 <!-- gateways:end -->
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ This repository contains a set of tests to evaluate and compare the compatibilit
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 199    |    🟢 46    |
 |                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    98.99%     | 🟢 197 ❌ 2  | 🟢 45 ❌ 1  |
 | [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
 |                               [Apollo Router](https://www.apollographql.com/)                               |    97.49%     | 🟢 194 ❌ 5  | 🟢 43 ❌ 3  |
 |                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.98%     | 🟢 193 ❌ 6  | 🟢 42 ❌ 4  |
 |                                   [Cosmo Router](https://wundergraph.com)                                   |    91.96%     | 🟢 183 ❌ 16 | 🟢 37 ❌ 9  |

--- a/REPORT.md
+++ b/REPORT.md
@@ -4,13 +4,13 @@
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 192    |    🟢 44    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    100.00%    |    🟢 192    |    🟢 44    |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 192    |    🟢 44    |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.40%     | 🟢 187 ❌ 5  | 🟢 41 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.88%     | 🟢 186 ❌ 6  | 🟢 40 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.75%     | 🟢 180 ❌ 12 | 🟢 36 ❌ 8  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.67%     | 🟢 176 ❌ 16 | 🟢 38 ❌ 6  |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 194    |    🟢 45    |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.42%     | 🟢 189 ❌ 5  | 🟢 42 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.91%     | 🟢 188 ❌ 6  | 🟢 41 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.81%     | 🟢 182 ❌ 12 | 🟢 37 ❌ 8  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.75%     | 🟢 178 ❌ 16 | 🟢 39 ❌ 6  |
 
 ## Detailed Results
 
@@ -79,6 +79,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -178,6 +180,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -277,6 +281,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -376,6 +382,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -475,6 +483,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -574,6 +584,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>❌</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -673,6 +685,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
 <pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>

--- a/REPORT.md
+++ b/REPORT.md
@@ -4,9 +4,9 @@
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    100.00%    |    🟢 199    |    🟢 46    |
 |                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    98.99%     | 🟢 197 ❌ 2  | 🟢 45 ❌ 1  |
 | [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
 |                               [Apollo Router](https://www.apollographql.com/)                               |    97.49%     | 🟢 194 ❌ 5  | 🟢 43 ❌ 3  |
 |                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.98%     | 🟢 193 ❌ 6  | 🟢 42 ❌ 4  |
 |                                   [Cosmo Router](https://wundergraph.com)                                   |    91.96%     | 🟢 183 ❌ 16 | 🟢 37 ❌ 9  |
@@ -17,6 +17,109 @@
 Take a closer look at the results for each gateway.
 
 You can look at the full list of tests [here](./src/test-suites/). Every test id corresponds to a directory in the `src/test-suites` folder.
+
+<a id="hive-router"></a>
+
+### Hive Router
+
+- [Repository](https://github.com/graphql-hive/router)
+- [Website](https://github.com/graphql-hive/router)
+
+<details>
+<summary>Results</summary>
+<a href="./src/test-suites/abstract-types">abstract-types</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/child-type-mismatch">child-type-mismatch</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/circular-reference-interface">circular-reference-interface</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/complex-entity-call">complex-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/corrupted-supergraph-node-id">corrupted-supergraph-node-id</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/enum-intersection">enum-intersection</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed1-external-extends">fed1-external-extends</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed1-external-extends-resolvable">fed1-external-extends-resolvable</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/fed1-external-extension">fed1-external-extension</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed2-external-extends">fed2-external-extends</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/fed2-external-extension">fed2-external-extension</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/include-skip">include-skip</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/input-object-intersection">input-object-intersection</a>
+<pre>🟢🟢🟢</pre>
+<a href="./src/test-suites/interface-object-indirect-extension">interface-object-indirect-extension</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/interface-object-with-requires">interface-object-with-requires</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/keys-mashup">keys-mashup</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/mutations">mutations</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/mysterious-external">mysterious-external</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/nested-provides">nested-provides</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/node">node</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/non-resolvable-interface-object">non-resolvable-interface-object</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/null-keys">null-keys</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/override-type-interface">override-type-interface</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/override-with-requires">override-with-requires</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/parent-entity-call">parent-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/partial-union">partial-union</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/provides-on-union">provides-on-union</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/requires-circular">requires-circular</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/requires-interface">requires-interface</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-requires">requires-requires</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-with-argument">requires-with-argument</a>
+<pre>🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/requires-with-argument-conflict">requires-with-argument-conflict</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/requires-with-fragments">requires-with-fragments</a>
+<pre>🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/shared-root">shared-root</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/simple-entity-call">simple-entity-call</a>
+<pre>🟢</pre>
+<a href="./src/test-suites/simple-inaccessible">simple-inaccessible</a>
+<pre>🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/simple-interface-object">simple-interface-object</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/simple-override">simple-override</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/simple-requires-provides">simple-requires-provides</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/typename">typename</a>
+<pre>🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/unavailable-override">unavailable-override</a>
+<pre>🟢🟢</pre>
+<a href="./src/test-suites/union-interface-distributed">union-interface-distributed</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+<a href="./src/test-suites/union-intersection">union-intersection</a>
+<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
+</details>
 
 <a id="hive-gateway"></a>
 
@@ -127,109 +230,6 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 
 - [Repository](https://github.com/graphql-hive/gateway)
 - [Website](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner)
-
-<details>
-<summary>Results</summary>
-<a href="./src/test-suites/abstract-types">abstract-types</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/child-type-mismatch">child-type-mismatch</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/circular-reference-interface">circular-reference-interface</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/complex-entity-call">complex-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/corrupted-supergraph-node-id">corrupted-supergraph-node-id</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/enum-intersection">enum-intersection</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed1-external-extends">fed1-external-extends</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed1-external-extends-resolvable">fed1-external-extends-resolvable</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/fed1-external-extension">fed1-external-extension</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed2-external-extends">fed2-external-extends</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/fed2-external-extension">fed2-external-extension</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/include-skip">include-skip</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/input-object-intersection">input-object-intersection</a>
-<pre>🟢🟢🟢</pre>
-<a href="./src/test-suites/interface-object-indirect-extension">interface-object-indirect-extension</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/interface-object-with-requires">interface-object-with-requires</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/keys-mashup">keys-mashup</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/mutations">mutations</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/mysterious-external">mysterious-external</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/nested-provides">nested-provides</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/node">node</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/non-resolvable-interface-object">non-resolvable-interface-object</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/null-keys">null-keys</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/override-type-interface">override-type-interface</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/override-with-requires">override-with-requires</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/parent-entity-call">parent-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/parent-entity-call-complex">parent-entity-call-complex</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/partial-union">partial-union</a>
-<pre>❌❌</pre>
-<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
-<pre>🟢🟢🟢🟢❌</pre>
-<a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/provides-on-union">provides-on-union</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/requires-circular">requires-circular</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/requires-interface">requires-interface</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-requires">requires-requires</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-with-argument">requires-with-argument</a>
-<pre>🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/requires-with-argument-conflict">requires-with-argument-conflict</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/requires-with-fragments">requires-with-fragments</a>
-<pre>🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/shared-root">shared-root</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/simple-entity-call">simple-entity-call</a>
-<pre>🟢</pre>
-<a href="./src/test-suites/simple-inaccessible">simple-inaccessible</a>
-<pre>🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/simple-interface-object">simple-interface-object</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/simple-override">simple-override</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/simple-requires-provides">simple-requires-provides</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/typename">typename</a>
-<pre>🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/unavailable-override">unavailable-override</a>
-<pre>🟢🟢</pre>
-<a href="./src/test-suites/union-interface-distributed">union-interface-distributed</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-<a href="./src/test-suites/union-intersection">union-intersection</a>
-<pre>🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢</pre>
-</details>
-
-<a id="hive-router"></a>
-
-### Hive Router
-
-- [Repository](https://github.com/graphql-hive/router)
-- [Website](https://github.com/graphql-hive/router)
 
 <details>
 <summary>Results</summary>

--- a/REPORT.md
+++ b/REPORT.md
@@ -4,13 +4,13 @@
 
 |                                                   Gateway                                                   | Compatibility |  Test Cases  | Test Suites |
 | :---------------------------------------------------------------------------------------------------------: | :-----------: | :----------: | :---------: |
-|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    100.00%    |    🟢 194    |    🟢 45    |
-| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
-|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.97%     | 🟢 192 ❌ 2  | 🟢 44 ❌ 1  |
-|                               [Apollo Router](https://www.apollographql.com/)                               |    97.42%     | 🟢 189 ❌ 5  | 🟢 42 ❌ 3  |
-|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.91%     | 🟢 188 ❌ 6  | 🟢 41 ❌ 4  |
-|                                   [Cosmo Router](https://wundergraph.com)                                   |    93.81%     | 🟢 182 ❌ 12 | 🟢 37 ❌ 8  |
-|                                  [Grafbase Gateway](https://grafbase.com)                                   |    91.75%     | 🟢 178 ❌ 16 | 🟢 39 ❌ 6  |
+|                         [Hive Gateway](https://the-guild.dev/graphql/hive/gateway)                          |    98.99%     | 🟢 197 ❌ 2  | 🟢 45 ❌ 1  |
+| [Hive Gateway (Rust QP)](https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner) |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
+|                            [Hive Router](https://github.com/graphql-hive/router)                            |    98.49%     | 🟢 196 ❌ 3  | 🟢 44 ❌ 2  |
+|                               [Apollo Router](https://www.apollographql.com/)                               |    97.49%     | 🟢 194 ❌ 5  | 🟢 43 ❌ 3  |
+|                              [Apollo Gateway](https://www.apollographql.com/)                               |    96.98%     | 🟢 193 ❌ 6  | 🟢 42 ❌ 4  |
+|                                   [Cosmo Router](https://wundergraph.com)                                   |    91.96%     | 🟢 183 ❌ 16 | 🟢 37 ❌ 9  |
+|                                  [Grafbase Gateway](https://grafbase.com)                                   |    90.45%     | 🟢 180 ❌ 19 | 🟢 39 ❌ 7  |
 
 ## Detailed Results
 
@@ -81,6 +81,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>❌❌🟢🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -182,6 +184,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>❌❌</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>🟢🟢🟢🟢❌</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -283,6 +287,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>❌❌</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>🟢🟢🟢🟢❌</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -384,6 +390,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -485,6 +493,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>🟢🟢🟢🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -586,6 +596,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>❌</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>❌❌❌❌🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>❌❌</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>
@@ -687,6 +699,8 @@ You can look at the full list of tests [here](./src/test-suites/). Every test id
 <pre>🟢</pre>
 <a href="./src/test-suites/partial-union">partial-union</a>
 <pre>🟢🟢</pre>
+<a href="./src/test-suites/partial-union-complex">partial-union-complex</a>
+<pre>❌❌❌🟢🟢</pre>
 <a href="./src/test-suites/provides-on-interface">provides-on-interface</a>
 <pre>🟢🟢</pre>
 <a href="./src/test-suites/provides-on-union">provides-on-union</a>

--- a/gateways/hive-router/install.sh
+++ b/gateways/hive-router/install.sh
@@ -1,2 +1,2 @@
 # https://github.com/graphql-hive/router/releases
-curl -fsSL https://raw.githubusercontent.com/graphql-hive/router/hive-router/v0.0.66/install.sh | sh -s v0.0.66
+curl -fsSL https://raw.githubusercontent.com/graphql-hive/router/hive-router/v0.0.71/install.sh | sh -s v0.0.71

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ async function getTestCases(router: ReturnType<typeof createRouter>) {
       import("./test-suites/keys-mashup/index.js"),
       import("./test-suites/null-keys/index.js"),
       import("./test-suites/requires-circular/index.js"),
+      import("./test-suites/partial-union/index.js"),
     ].map((i) => i.then((e) => e.default)),
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ async function getTestCases(router: ReturnType<typeof createRouter>) {
       import("./test-suites/null-keys/index.js"),
       import("./test-suites/requires-circular/index.js"),
       import("./test-suites/partial-union/index.js"),
+      import("./test-suites/partial-union-complex/index.js"),
     ].map((i) => i.then((e) => e.default)),
   );
 

--- a/src/test-suites/partial-union-complex/README.md
+++ b/src/test-suites/partial-union-complex/README.md
@@ -1,0 +1,7 @@
+# Partial Union Complex
+
+A partial union appears below shareable fields, including a shareable field in the middle of the query path and an entity hop to another subgraph.
+
+The gateway must keep union member fragments based on the subgraphs that can still resolve the current path, not based on a global intersection of all union members.
+
+If an entity-representable shareable path can still be resolved in multiple subgraphs, only members common to those candidate subgraphs are guaranteed safe. If a field forces an entity hop before the union, the target subgraph's members should be used.

--- a/src/test-suites/partial-union-complex/a.subgraph.ts
+++ b/src/test-suites/partial-union-complex/a.subgraph.ts
@@ -1,0 +1,59 @@
+import { createSubgraph } from "../../subgraph.js";
+import { aActions, container, sharedActions } from "./data.js";
+
+export default createSubgraph("a", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable"]
+      )
+
+    type Query {
+      rootA: Container
+      shared: Container @shareable
+    }
+
+    type Container @key(fields: "id") {
+      id: ID!
+      wrapper: Wrapper @shareable
+    }
+
+    type Wrapper @shareable {
+      actions: [Action!]! @shareable
+    }
+
+    union Action = Common | OnlyA
+
+    type Common @shareable {
+      label: String
+    }
+
+    type OnlyA {
+      a: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      rootA: () => ({ ...container, actions: aActions }),
+      shared: () => ({ ...container, actions: sharedActions }),
+    },
+    Container: {
+      __resolveReference(key: { id: string }) {
+        if (key.id !== container.id) {
+          return null;
+        }
+
+        return { ...container, actions: aActions };
+      },
+      wrapper(parent: { actions?: typeof aActions }) {
+        return { actions: parent.actions ?? aActions };
+      },
+    },
+    Action: {
+      __resolveType(value: { __typename: string }) {
+        return value.__typename;
+      },
+    },
+  },
+});

--- a/src/test-suites/partial-union-complex/b.subgraph.ts
+++ b/src/test-suites/partial-union-complex/b.subgraph.ts
@@ -1,0 +1,63 @@
+import { createSubgraph } from "../../subgraph.js";
+import { bActions, container, sharedActions } from "./data.js";
+
+export default createSubgraph("b", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.3"
+        import: ["@key", "@shareable"]
+      )
+
+    type Query {
+      rootB: Container
+      shared: Container @shareable
+    }
+
+    type Container @key(fields: "id") {
+      id: ID!
+      wrapper: Wrapper @shareable
+      bWrapper: Wrapper
+    }
+
+    type Wrapper @shareable {
+      actions: [Action!]! @shareable
+    }
+
+    union Action = Common | OnlyB
+
+    type Common @shareable {
+      label: String
+    }
+
+    type OnlyB {
+      b: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      rootB: () => ({ ...container, actions: bActions }),
+      shared: () => ({ ...container, actions: sharedActions }),
+    },
+    Container: {
+      __resolveReference(key: { id: string }) {
+        if (key.id !== container.id) {
+          return null;
+        }
+
+        return { ...container, actions: bActions };
+      },
+      wrapper(parent: { actions?: typeof bActions }) {
+        return { actions: parent.actions ?? bActions };
+      },
+      bWrapper() {
+        return { actions: bActions };
+      },
+    },
+    Action: {
+      __resolveType(value: { __typename: string }) {
+        return value.__typename;
+      },
+    },
+  },
+});

--- a/src/test-suites/partial-union-complex/data.ts
+++ b/src/test-suites/partial-union-complex/data.ts
@@ -1,0 +1,22 @@
+export const common = {
+  __typename: "Common",
+  label: "common label",
+};
+
+export const onlyA = {
+  __typename: "OnlyA",
+  a: "only a",
+};
+
+export const onlyB = {
+  __typename: "OnlyB",
+  b: "only b",
+};
+
+export const container = {
+  id: "container-1",
+};
+
+export const aActions = [common, onlyA];
+export const bActions = [common, onlyB];
+export const sharedActions = [common];

--- a/src/test-suites/partial-union-complex/index.ts
+++ b/src/test-suites/partial-union-complex/index.ts
@@ -1,0 +1,6 @@
+import { serve } from "../../supergraph.js";
+import a from "./a.subgraph.js";
+import b from "./b.subgraph.js";
+import test from "./test.js";
+
+export default serve("partial-union-complex", [a, b], test);

--- a/src/test-suites/partial-union-complex/test.ts
+++ b/src/test-suites/partial-union-complex/test.ts
@@ -34,7 +34,7 @@ export default [
               },
               {
                 __typename: onlyA.__typename,
-                a: onlyA.a,
+                a: null,
               },
             ],
           },
@@ -74,7 +74,7 @@ export default [
               },
               {
                 __typename: onlyB.__typename,
-                b: onlyB.b,
+                b: null,
               },
             ],
           },

--- a/src/test-suites/partial-union-complex/test.ts
+++ b/src/test-suites/partial-union-complex/test.ts
@@ -1,0 +1,193 @@
+import { createTest } from "../../testkit.js";
+import { common, onlyA, onlyB } from "./data.js";
+
+export default [
+  createTest(
+    /* GraphQL */ `
+      query {
+        rootA {
+          wrapper {
+            actions {
+              __typename
+              ... on Common {
+                label
+              }
+              ... on OnlyA {
+                a
+              }
+              ... on OnlyB {
+                b
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        rootA: {
+          wrapper: {
+            actions: [
+              {
+                __typename: common.__typename,
+                label: common.label,
+              },
+              {
+                __typename: onlyA.__typename,
+                a: onlyA.a,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ),
+  createTest(
+    /* GraphQL */ `
+      query {
+        rootB {
+          wrapper {
+            actions {
+              __typename
+              ... on Common {
+                label
+              }
+              ... on OnlyA {
+                a
+              }
+              ... on OnlyB {
+                b
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        rootB: {
+          wrapper: {
+            actions: [
+              {
+                __typename: common.__typename,
+                label: common.label,
+              },
+              {
+                __typename: onlyB.__typename,
+                b: onlyB.b,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ),
+  createTest(
+    /* GraphQL */ `
+      query {
+        rootA {
+          wrapper {
+            actions {
+              __typename
+              ... on OnlyB {
+                b
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        rootA: {
+          wrapper: {
+            actions: [
+              {
+                __typename: common.__typename,
+              },
+              {
+                __typename: onlyA.__typename,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ),
+  createTest(
+    /* GraphQL */ `
+      query {
+        shared {
+          wrapper {
+            actions {
+              __typename
+              ... on Common {
+                label
+              }
+              ... on OnlyA {
+                a
+              }
+              ... on OnlyB {
+                b
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        shared: {
+          wrapper: {
+            actions: [
+              {
+                __typename: common.__typename,
+                label: common.label,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ),
+  createTest(
+    /* GraphQL */ `
+      query {
+        rootA {
+          bWrapper {
+            actions {
+              __typename
+              ... on Common {
+                label
+              }
+              ... on OnlyA {
+                a
+              }
+              ... on OnlyB {
+                b
+              }
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        rootA: {
+          bWrapper: {
+            actions: [
+              {
+                __typename: common.__typename,
+                label: common.label,
+              },
+              {
+                __typename: onlyB.__typename,
+                b: onlyB.b,
+              },
+            ],
+          },
+        },
+      },
+    },
+  ),
+];

--- a/src/test-suites/partial-union/README.md
+++ b/src/test-suites/partial-union/README.md
@@ -1,0 +1,17 @@
+# Partial Union
+
+A `@shareable` type contains a union whose members differ across subgraphs (a
+"partial union"). 
+
+The primary subgraph declares the full union
+(`Alpha | Beta | Gamma`) while the secondary subgraph declares only `Alpha`.
+
+None of the union members define a `@key`, so members missing from a subgraph
+can never be reached through entity resolution.
+
+A correct gateway must keep every inline fragment in the operation and resolve
+the field from the subgraph that actually knows the full union. 
+
+A buggy planner may instead strip the inline fragments for `Beta` and `Gamma` — assuming they
+can be fetched later via entity resolution — which makes those fields return
+`null`.

--- a/src/test-suites/partial-union/a.subgraph.ts
+++ b/src/test-suites/partial-union/a.subgraph.ts
@@ -1,0 +1,47 @@
+import { createSubgraph } from "../../subgraph.js";
+import { actions, message } from "./data.js";
+
+// "primary" subgraph: declares the full union `Alpha | Beta | Gamma` and is the
+// only subgraph that defines `getResponse`. `Beta` and `Gamma` have no `@key`,
+// so they can only ever be resolved here.
+export default createSubgraph("a", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.0"
+        import: ["@key", "@shareable"]
+      )
+
+    type Query {
+      getResponse: Response
+    }
+
+    type Response @shareable {
+      actions: [Action!]!
+      message: String
+    }
+
+    union Action = Alpha | Beta | Gamma
+
+    type Alpha @shareable {
+      id: ID!
+      value: String
+    }
+
+    type Beta {
+      id: ID!
+      name: String
+      details: String
+    }
+
+    type Gamma {
+      id: ID!
+      label: String
+    }
+  `,
+  resolvers: {
+    Query: {
+      getResponse: () => ({ message, actions }),
+    },
+  },
+});

--- a/src/test-suites/partial-union/b.subgraph.ts
+++ b/src/test-suites/partial-union/b.subgraph.ts
@@ -1,0 +1,30 @@
+import { createSubgraph } from "../../subgraph.js";
+
+// "secondary" subgraph: contributes only a partial union (`Alpha` only) and the
+// shared `@shareable Response` type. It does NOT define `getResponse`, so the
+// planner must resolve the whole field from the primary subgraph. Its only role
+// is to make `Action` a partial union across the supergraph: a buggy planner
+// sees that `Response`/`Alpha` are shareable here and wrongly assumes `Beta`
+// and `Gamma` can be fetched via entity resolution, stripping their fragments.
+export default createSubgraph("b", {
+  typeDefs: /* GraphQL */ `
+    extend schema
+      @link(
+        url: "https://specs.apollo.dev/federation/v2.0"
+        import: ["@key", "@shareable"]
+      )
+
+    type Response @shareable {
+      actions: [Action!]!
+      message: String
+    }
+
+    union Action = Alpha
+
+    type Alpha @shareable {
+      id: ID!
+      value: String
+    }
+  `,
+  resolvers: {},
+});

--- a/src/test-suites/partial-union/data.ts
+++ b/src/test-suites/partial-union/data.ts
@@ -1,0 +1,23 @@
+export const message = "Hello, Federation!";
+
+export const alpha = {
+  __typename: "Alpha",
+  id: "alpha-1",
+  value: "alpha value",
+};
+
+export const beta = {
+  __typename: "Beta",
+  id: "beta-1",
+  name: "beta name",
+  details: "beta details",
+};
+
+export const gamma = {
+  __typename: "Gamma",
+  id: "gamma-1",
+  label: "gamma label",
+};
+
+// The primary subgraph can resolve all three union members.
+export const actions = [alpha, beta, gamma];

--- a/src/test-suites/partial-union/index.ts
+++ b/src/test-suites/partial-union/index.ts
@@ -1,0 +1,6 @@
+import { serve } from "../../supergraph.js";
+import a from "./a.subgraph.js";
+import b from "./b.subgraph.js";
+import test from "./test.js";
+
+export default serve("partial-union", [a, b], test);

--- a/src/test-suites/partial-union/test.ts
+++ b/src/test-suites/partial-union/test.ts
@@ -1,0 +1,88 @@
+import { createTest } from "../../testkit.js";
+import { alpha, beta, gamma, message } from "./data.js";
+
+export default [
+  // The query selects all three union members. `Beta` and `Gamma` exist only
+  // in the primary subgraph and have no `@key`, so they can only be resolved
+  // there. A correct gateway keeps every inline fragment and returns all three.
+  createTest(
+    /* GraphQL */ `
+      query {
+        getResponse {
+          message
+          actions {
+            __typename
+            ... on Alpha {
+              id
+              value
+            }
+            ... on Beta {
+              id
+              name
+              details
+            }
+            ... on Gamma {
+              id
+              label
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        getResponse: {
+          message,
+          actions: [
+            {
+              __typename: alpha.__typename,
+              id: alpha.id,
+              value: alpha.value,
+            },
+            {
+              __typename: beta.__typename,
+              id: beta.id,
+              name: beta.name,
+              details: beta.details,
+            },
+            {
+              __typename: gamma.__typename,
+              id: gamma.id,
+              label: gamma.label,
+            },
+          ],
+        },
+      },
+    },
+  ),
+  // Selecting only the members missing from the secondary subgraph must still
+  // resolve them from the primary subgraph.
+  createTest(
+    /* GraphQL */ `
+      query {
+        getResponse {
+          actions {
+            __typename
+            ... on Beta {
+              name
+            }
+            ... on Gamma {
+              label
+            }
+          }
+        }
+      }
+    `,
+    {
+      data: {
+        getResponse: {
+          actions: [
+            { __typename: alpha.__typename },
+            { __typename: beta.__typename, name: beta.name },
+            { __typename: gamma.__typename, label: gamma.label },
+          ],
+        },
+      },
+    },
+  ),
+];

--- a/website/data.json
+++ b/website/data.json
@@ -1,5 +1,18 @@
 [
   {
+    "name": "Hive Router",
+    "cases": {
+      "total": 199,
+      "passed": 199,
+      "failed": 0
+    },
+    "suites": {
+      "total": 46,
+      "passed": 46,
+      "failed": 0
+    }
+  },
+  {
     "name": "Hive Gateway",
     "cases": {
       "total": 199,
@@ -14,19 +27,6 @@
   },
   {
     "name": "Hive Gateway (Rust QP)",
-    "cases": {
-      "total": 199,
-      "passed": 196,
-      "failed": 3
-    },
-    "suites": {
-      "total": 46,
-      "passed": 44,
-      "failed": 2
-    }
-  },
-  {
-    "name": "Hive Router",
     "cases": {
       "total": 199,
       "passed": 196,

--- a/website/data.json
+++ b/website/data.json
@@ -2,92 +2,92 @@
   {
     "name": "Hive Gateway",
     "cases": {
-      "total": 194,
-      "passed": 194,
-      "failed": 0
+      "total": 199,
+      "passed": 197,
+      "failed": 2
     },
     "suites": {
-      "total": 45,
+      "total": 46,
       "passed": 45,
-      "failed": 0
+      "failed": 1
     }
   },
   {
     "name": "Hive Gateway (Rust QP)",
     "cases": {
-      "total": 194,
-      "passed": 192,
-      "failed": 2
+      "total": 199,
+      "passed": 196,
+      "failed": 3
     },
     "suites": {
-      "total": 45,
+      "total": 46,
       "passed": 44,
-      "failed": 1
+      "failed": 2
     }
   },
   {
     "name": "Hive Router",
     "cases": {
-      "total": 194,
-      "passed": 192,
-      "failed": 2
+      "total": 199,
+      "passed": 196,
+      "failed": 3
     },
     "suites": {
-      "total": 45,
+      "total": 46,
       "passed": 44,
-      "failed": 1
+      "failed": 2
     }
   },
   {
     "name": "Apollo Router",
     "cases": {
-      "total": 194,
-      "passed": 189,
+      "total": 199,
+      "passed": 194,
       "failed": 5
     },
     "suites": {
-      "total": 45,
-      "passed": 42,
+      "total": 46,
+      "passed": 43,
       "failed": 3
     }
   },
   {
     "name": "Apollo Gateway",
     "cases": {
-      "total": 194,
-      "passed": 188,
+      "total": 199,
+      "passed": 193,
       "failed": 6
     },
     "suites": {
-      "total": 45,
-      "passed": 41,
+      "total": 46,
+      "passed": 42,
       "failed": 4
     }
   },
   {
     "name": "Cosmo Router",
     "cases": {
-      "total": 194,
-      "passed": 182,
-      "failed": 12
+      "total": 199,
+      "passed": 183,
+      "failed": 16
     },
     "suites": {
-      "total": 45,
+      "total": 46,
       "passed": 37,
-      "failed": 8
+      "failed": 9
     }
   },
   {
     "name": "Grafbase Gateway",
     "cases": {
-      "total": 194,
-      "passed": 178,
-      "failed": 16
+      "total": 199,
+      "passed": 180,
+      "failed": 19
     },
     "suites": {
-      "total": 45,
+      "total": 46,
       "passed": 39,
-      "failed": 6
+      "failed": 7
     }
   }
 ]

--- a/website/data.json
+++ b/website/data.json
@@ -2,91 +2,91 @@
   {
     "name": "Hive Gateway",
     "cases": {
-      "total": 192,
-      "passed": 192,
+      "total": 194,
+      "passed": 194,
       "failed": 0
     },
     "suites": {
-      "total": 44,
-      "passed": 44,
+      "total": 45,
+      "passed": 45,
       "failed": 0
     }
   },
   {
     "name": "Hive Gateway (Rust QP)",
     "cases": {
-      "total": 192,
+      "total": 194,
       "passed": 192,
-      "failed": 0
+      "failed": 2
     },
     "suites": {
-      "total": 44,
+      "total": 45,
       "passed": 44,
-      "failed": 0
+      "failed": 1
     }
   },
   {
     "name": "Hive Router",
     "cases": {
-      "total": 192,
+      "total": 194,
       "passed": 192,
-      "failed": 0
+      "failed": 2
     },
     "suites": {
-      "total": 44,
+      "total": 45,
       "passed": 44,
-      "failed": 0
+      "failed": 1
     }
   },
   {
     "name": "Apollo Router",
     "cases": {
-      "total": 192,
-      "passed": 187,
+      "total": 194,
+      "passed": 189,
       "failed": 5
     },
     "suites": {
-      "total": 44,
-      "passed": 41,
+      "total": 45,
+      "passed": 42,
       "failed": 3
     }
   },
   {
     "name": "Apollo Gateway",
     "cases": {
-      "total": 192,
-      "passed": 186,
+      "total": 194,
+      "passed": 188,
       "failed": 6
     },
     "suites": {
-      "total": 44,
-      "passed": 40,
+      "total": 45,
+      "passed": 41,
       "failed": 4
     }
   },
   {
     "name": "Cosmo Router",
     "cases": {
-      "total": 192,
-      "passed": 180,
+      "total": 194,
+      "passed": 182,
       "failed": 12
     },
     "suites": {
-      "total": 44,
-      "passed": 36,
+      "total": 45,
+      "passed": 37,
       "failed": 8
     }
   },
   {
     "name": "Grafbase Gateway",
     "cases": {
-      "total": 192,
-      "passed": 176,
+      "total": 194,
+      "passed": 178,
       "failed": 16
     },
     "suites": {
-      "total": 44,
-      "passed": 38,
+      "total": 45,
+      "passed": 39,
       "failed": 6
     }
   }

--- a/website/index.html
+++ b/website/index.html
@@ -239,6 +239,34 @@
 
                   <tr class="border-b transition-colors hover:bg-gray-100/50">
                     <td
+                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
+                    >
+                      <a
+                        href="https://github.com/graphql-hive/router"
+                        class="hover:underline"
+                        title="Visit Hive Router website"
+                      >
+                        Hive Router
+                      </a>
+                    </td>
+                    <td class="p-4 align-middle font-semibold">100.00%</td>
+                    <td class="p-4 align-middle">
+                      <span class="text-emerald-700 mr-2">✓ 199</span>
+                    </td>
+                    <td class="p-4 align-middle">
+                      <span class="text-emerald-700 mr-2">✓ 46</span>
+                    </td>
+                    <td class="p-4 align-middle">
+                      <a
+                        href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-router"
+                        class="text-sky-700 hover:underline"
+                        >View report</a
+                      >
+                    </td>
+                  </tr>
+
+                  <tr class="border-b transition-colors hover:bg-gray-100/50">
+                    <td
                       class="p-4 align-middle font-medium border-l-2 border-yellow-500"
                     >
                       <a
@@ -291,36 +319,6 @@
                     <td class="p-4 align-middle">
                       <a
                         href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-gateway-router-runtime"
-                        class="text-sky-700 hover:underline"
-                        >View report</a
-                      >
-                    </td>
-                  </tr>
-
-                  <tr class="border-b transition-colors hover:bg-gray-100/50">
-                    <td
-                      class="p-4 align-middle font-medium border-l-2 border-yellow-500"
-                    >
-                      <a
-                        href="https://github.com/graphql-hive/router"
-                        class="hover:underline"
-                        title="Visit Hive Router website"
-                      >
-                        Hive Router
-                      </a>
-                    </td>
-                    <td class="p-4 align-middle font-semibold">98.49%</td>
-                    <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 196</span>
-                      <span class="text-red-700">✗ 3</span>
-                    </td>
-                    <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 44</span>
-                      <span class="text-red-700">✗ 2</span>
-                    </td>
-                    <td class="p-4 align-middle">
-                      <a
-                        href="https://github.com/the-guild-org/federation-compatibility/tree/main/REPORT.md#hive-router"
                         class="text-sky-700 hover:underline"
                         >View report</a
                       >

--- a/website/index.html
+++ b/website/index.html
@@ -251,10 +251,10 @@
                     </td>
                     <td class="p-4 align-middle font-semibold">100.00%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
+                      <span class="text-emerald-700 mr-2">✓ 194</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-emerald-700 mr-2">✓ 45</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -267,7 +267,7 @@
 
                   <tr class="border-b transition-colors hover:bg-gray-100/50">
                     <td
-                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
+                      class="p-4 align-middle font-medium border-l-2 border-yellow-500"
                     >
                       <a
                         href="https://the-guild.dev/graphql/hive/docs/gateway/other-features/rust-query-planner"
@@ -277,12 +277,14 @@
                         Hive Gateway (Rust QP)
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">100.00%</td>
+                    <td class="p-4 align-middle font-semibold">98.97%</td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 192</span>
+                      <span class="text-red-700">✗ 2</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-red-700">✗ 1</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -295,7 +297,7 @@
 
                   <tr class="border-b transition-colors hover:bg-gray-100/50">
                     <td
-                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
+                      class="p-4 align-middle font-medium border-l-2 border-yellow-500"
                     >
                       <a
                         href="https://github.com/graphql-hive/router"
@@ -305,12 +307,14 @@
                         Hive Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">100.00%</td>
+                    <td class="p-4 align-middle font-semibold">98.97%</td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 192</span>
+                      <span class="text-red-700">✗ 2</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 44</span>
+                      <span class="text-red-700">✗ 1</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -333,13 +337,13 @@
                         Apollo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">97.40%</td>
+                    <td class="p-4 align-middle font-semibold">97.42%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 187</span>
+                      <span class="text-emerald-700 mr-2">✓ 189</span>
                       <span class="text-red-700">✗ 5</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 41</span>
+                      <span class="text-emerald-700 mr-2">✓ 42</span>
                       <span class="text-red-700">✗ 3</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -363,13 +367,13 @@
                         Apollo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">96.88%</td>
+                    <td class="p-4 align-middle font-semibold">96.91%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 186</span>
+                      <span class="text-emerald-700 mr-2">✓ 188</span>
                       <span class="text-red-700">✗ 6</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 40</span>
+                      <span class="text-emerald-700 mr-2">✓ 41</span>
                       <span class="text-red-700">✗ 4</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -393,13 +397,13 @@
                         Cosmo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">93.75%</td>
+                    <td class="p-4 align-middle font-semibold">93.81%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 180</span>
+                      <span class="text-emerald-700 mr-2">✓ 182</span>
                       <span class="text-red-700">✗ 12</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 36</span>
+                      <span class="text-emerald-700 mr-2">✓ 37</span>
                       <span class="text-red-700">✗ 8</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -423,13 +427,13 @@
                         Grafbase Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">91.67%</td>
+                    <td class="p-4 align-middle font-semibold">91.75%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 176</span>
+                      <span class="text-emerald-700 mr-2">✓ 178</span>
                       <span class="text-red-700">✗ 16</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 38</span>
+                      <span class="text-emerald-700 mr-2">✓ 39</span>
                       <span class="text-red-700">✗ 6</span>
                     </td>
                     <td class="p-4 align-middle">

--- a/website/index.html
+++ b/website/index.html
@@ -239,7 +239,7 @@
 
                   <tr class="border-b transition-colors hover:bg-gray-100/50">
                     <td
-                      class="p-4 align-middle font-medium border-l-2 border-emerald-500"
+                      class="p-4 align-middle font-medium border-l-2 border-yellow-500"
                     >
                       <a
                         href="https://the-guild.dev/graphql/hive/gateway"
@@ -249,12 +249,14 @@
                         Hive Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">100.00%</td>
+                    <td class="p-4 align-middle font-semibold">98.99%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 194</span>
+                      <span class="text-emerald-700 mr-2">✓ 197</span>
+                      <span class="text-red-700">✗ 2</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 45</span>
+                      <span class="text-red-700">✗ 1</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -277,14 +279,14 @@
                         Hive Gateway (Rust QP)
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">98.97%</td>
+                    <td class="p-4 align-middle font-semibold">98.49%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
-                      <span class="text-red-700">✗ 2</span>
+                      <span class="text-emerald-700 mr-2">✓ 196</span>
+                      <span class="text-red-700">✗ 3</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 44</span>
-                      <span class="text-red-700">✗ 1</span>
+                      <span class="text-red-700">✗ 2</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -307,14 +309,14 @@
                         Hive Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">98.97%</td>
+                    <td class="p-4 align-middle font-semibold">98.49%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 192</span>
-                      <span class="text-red-700">✗ 2</span>
+                      <span class="text-emerald-700 mr-2">✓ 196</span>
+                      <span class="text-red-700">✗ 3</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 44</span>
-                      <span class="text-red-700">✗ 1</span>
+                      <span class="text-red-700">✗ 2</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -337,13 +339,13 @@
                         Apollo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">97.42%</td>
+                    <td class="p-4 align-middle font-semibold">97.49%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 189</span>
+                      <span class="text-emerald-700 mr-2">✓ 194</span>
                       <span class="text-red-700">✗ 5</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 42</span>
+                      <span class="text-emerald-700 mr-2">✓ 43</span>
                       <span class="text-red-700">✗ 3</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -367,13 +369,13 @@
                         Apollo Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">96.91%</td>
+                    <td class="p-4 align-middle font-semibold">96.98%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 188</span>
+                      <span class="text-emerald-700 mr-2">✓ 193</span>
                       <span class="text-red-700">✗ 6</span>
                     </td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 41</span>
+                      <span class="text-emerald-700 mr-2">✓ 42</span>
                       <span class="text-red-700">✗ 4</span>
                     </td>
                     <td class="p-4 align-middle">
@@ -397,14 +399,14 @@
                         Cosmo Router
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">93.81%</td>
+                    <td class="p-4 align-middle font-semibold">91.96%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 182</span>
-                      <span class="text-red-700">✗ 12</span>
+                      <span class="text-emerald-700 mr-2">✓ 183</span>
+                      <span class="text-red-700">✗ 16</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 37</span>
-                      <span class="text-red-700">✗ 8</span>
+                      <span class="text-red-700">✗ 9</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a
@@ -427,14 +429,14 @@
                         Grafbase Gateway
                       </a>
                     </td>
-                    <td class="p-4 align-middle font-semibold">91.75%</td>
+                    <td class="p-4 align-middle font-semibold">90.45%</td>
                     <td class="p-4 align-middle">
-                      <span class="text-emerald-700 mr-2">✓ 178</span>
-                      <span class="text-red-700">✗ 16</span>
+                      <span class="text-emerald-700 mr-2">✓ 180</span>
+                      <span class="text-red-700">✗ 19</span>
                     </td>
                     <td class="p-4 align-middle">
                       <span class="text-emerald-700 mr-2">✓ 39</span>
-                      <span class="text-red-700">✗ 6</span>
+                      <span class="text-red-700">✗ 7</span>
                     </td>
                     <td class="p-4 align-middle">
                       <a


### PR DESCRIPTION
## Partial Union

A `@shareable` type contains a union whose members differ across subgraphs (a
"partial union"). 

The primary subgraph declares the full union (`Alpha | Beta | Gamma`) while the secondary subgraph declares only `Alpha`.

None of the union members define a `@key`, so members missing from a subgraph can never be reached through entity resolution.

A correct gateway must keep every inline fragment in the operation and resolve the field from the subgraph that actually knows the full union. 

A buggy planner may instead strip the inline fragments for `Beta` and `Gamma` — assuming they
can be fetched later via entity resolution — which makes those fields return
`null`.

Based on https://github.com/graphql-hive/router/issues/1098 , https://github.com/graphql-hive/gateway/issues/2381 

